### PR TITLE
Remove `println` calls from lib code

### DIFF
--- a/src/extension.rs
+++ b/src/extension.rs
@@ -29,7 +29,6 @@ impl Extender {
         match source.read_exact(&mut extension) {
             Ok(()) => Ok(Some(extension.into())),
             Err(ref e) if e.kind() == IoErrorKind::UnexpectedEof => {
-                println!("[Extender]: No data!");
                 Ok(None)
             }
             Err(e) => Err(NiftiError::from(e)),

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -57,7 +57,6 @@ impl InMemNiftiVolume {
             .map(|d| *d as usize)
             .product();
         let nbytes = resolution * header.bitpix as usize / 8;
-        println!("Reading volume of {:?} bytes", nbytes);
         let mut raw_data = vec![0u8; nbytes];
         source.read_exact(&mut raw_data)?;
 


### PR DESCRIPTION
I had probably added them as a lazy means of debugging, but forgot to remove them. Resolves #6.