### PR TITLE
Data Element API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,14 @@ branch = "master"
 repository = "Enet4/nifti-rs"
 
 [dependencies]
-asprim = "0.1.1"
 byteorder = "1.2.1"
+derive_builder = "0.5.1"
 flate2 = "1.0.1"
-num = "0.1.40"
+num = "0.1.41"
 num-derive = "0.1.41"
-num-traits = "0.1.40"
+num-traits = "0.2.0"
 quick-error = "1.2.0"
 safe-transmute = "0.7.0"
-derive_builder = "0.5.1"
 
 [dependencies.ndarray]
 optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,16 +51,11 @@
 #[macro_use] extern crate num_derive;
 #[macro_use] extern crate derive_builder;
 #[cfg(feature = "ndarray_volumes")] extern crate ndarray;
-#[cfg(feature = "ndarray_volumes")] extern crate safe_transmute;
 
-#[cfg(test)]
-#[macro_use]
-extern crate approx;
-
-extern crate asprim;
 extern crate byteorder;
 extern crate flate2;
-extern crate num;
+extern crate num_traits;
+extern crate safe_transmute;
 
 pub mod extension;
 pub mod header;
@@ -70,12 +65,12 @@ pub mod error;
 pub mod typedef;
 mod util;
 
-pub use asprim::AsPrim;
 pub use error::{NiftiError, Result};
 pub use object::{NiftiObject, InMemNiftiObject};
 pub use extension::{Extender, Extension, ExtensionSequence};
 pub use header::{NiftiHeader, NiftiHeaderBuilder};
 pub use volume::{NiftiVolume, InMemNiftiVolume, Sliceable};
+pub use volume::element::DataElement;
 #[cfg(feature = "ndarray_volumes")] pub use volume::ndarray::IntoNdArray;
 pub use typedef::{NiftiType, Unit, Intent, XForm, SliceOrder};
 pub use util::Endianness;

--- a/src/volume/element.rs
+++ b/src/volume/element.rs
@@ -1,0 +1,197 @@
+//! This module defines the data element API, which enables NIfTI
+//! volume API implementations to read, write and convert data
+//! elements.
+use std::io::Read;
+use std::ops::{Mul, Add};
+use std::mem::align_of;
+use byteorder::ReadBytesExt;
+use safe_transmute::guarded_transmute_pod_vec_permissive;
+use error::Result;
+use num_traits::cast::AsPrimitive;
+use util::{Endianness, convert_bytes_to};
+
+/// Interface for linear (affine) transformations to values. Multiple
+/// implementations are needed because the original type `T` may not
+/// have enough precision to obtain an appropriate outcome.
+pub trait LinearTransform<T: 'static + Copy> {
+    /// Linearly transform a value with the given slope and intercept.
+    fn linear_transform(value: T, slope: f32, intercept: f32) -> T;
+
+    /// Linearly transform a sequence of values with the given slope and intercept into
+    /// a vector.
+    fn linear_transform_many(value: &[T], slope: f32, intercept: f32) -> Vec<T> {
+        value.iter()
+            .map(|x| Self::linear_transform(*x, slope, intercept))
+            .collect()
+    }
+
+    /// Linearly transform a sequence of values inline, with the given slope and intercept.
+    fn linear_transform_many_inline(value: &mut [T], slope: f32, intercept: f32) {
+        for v in value.iter_mut() {
+            *v = Self::linear_transform(*v, slope, intercept);
+        }
+    }
+}
+
+/// A linear transformation in which the value is converted to `f32` for the
+/// affine transformation, then converted back to the original type. Ideal for
+/// small, low precision types such as `u8` and `i16`.
+#[derive(Debug)]
+pub struct LinearTransformViaF32;
+
+impl<T> LinearTransform<T> for LinearTransformViaF32
+where
+    T: AsPrimitive<f32>,
+    f32: AsPrimitive<T>,
+{
+    fn linear_transform(value: T, slope: f32, intercept: f32) -> T {
+        if slope == 0. { return value }
+        (value.as_() * slope + intercept).as_()
+    }
+}
+
+/// A linear transformation in which the value and parameters are converted to
+/// `f64` for the affine transformation, then converted to the original type.
+/// Ideal for wide integer types such as `i64`.
+#[derive(Debug)]
+pub struct LinearTransformViaF64;
+
+impl<T> LinearTransform<T> for LinearTransformViaF64
+where
+    T: 'static + Copy + AsPrimitive<f64>,
+    f64: AsPrimitive<T>,
+{
+    fn linear_transform(value: T, slope: f32, intercept: f32) -> T {
+        if slope == 0. { return value }
+        let slope: f64 = slope.as_();
+        let intercept: f64 = intercept.as_();
+        (value.as_() * slope + intercept).as_()
+    }
+}
+
+/// A linear transformation in which the slope and intercept parameters are
+/// converted to the value's type for the affine transformation. Ideal
+/// for high precision or complex number types.
+#[derive(Debug)]
+pub struct LinearTransformViaOriginal;
+
+impl<T> LinearTransform<T> for LinearTransformViaOriginal
+where
+    T: 'static + DataElement + Mul<Output = T> + Add<Output = T> + Copy,
+    f32: AsPrimitive<T>,
+{
+    fn linear_transform(value: T, slope: f32, intercept: f32) -> T {
+        if slope == 0. { return value }
+        let slope: T = slope.as_();
+        let intercept: T = intercept.as_();
+        value * slope + intercept
+    }
+}
+
+/// Trait type for characterizing a NIfTI data element.
+pub trait DataElement: 'static + Sized + Copy + AsPrimitive<u8> + AsPrimitive<f32> + AsPrimitive<f64>
+{
+    /// For defining how this element is linearly transformed to another.
+    type Transform: LinearTransform<Self>;
+
+    /// Read a single element from the given byte source.
+    fn from_raw<R: Read>(src: R, endianness: Endianness) -> Result<Self>;
+
+    /// Transform the given data vector into a vector of data elements.
+    fn from_raw_vec(vec: Vec<u8>, endianness: Endianness) -> Result<Vec<Self>> {
+        let mut cursor: &[u8] = &vec;
+        let n = align_of::<Self>();
+        (0..n).map(|_| Self::from_raw(&mut cursor, endianness)).collect()
+    }
+}
+
+impl DataElement for u8 {
+    type Transform = LinearTransformViaF32;
+    fn from_raw_vec(vec: Vec<u8>, _: Endianness) -> Result<Vec<Self>> {
+        Ok(vec)
+    }
+    fn from_raw<R: Read>(mut src: R, _: Endianness) -> Result<Self> {
+        src.read_u8().map_err(From::from)
+    }
+}
+impl DataElement for i8 {
+    type Transform = LinearTransformViaF32;
+    fn from_raw_vec(vec: Vec<u8>, _: Endianness) -> Result<Vec<Self>> {
+        Ok(guarded_transmute_pod_vec_permissive(vec))
+    }
+    fn from_raw<R: Read>(mut src: R, _: Endianness) -> Result<Self> {
+        src.read_i8().map_err(From::from)
+    }
+}
+impl DataElement for u16 {
+    type Transform = LinearTransformViaF32;
+    fn from_raw_vec(vec: Vec<u8>, e: Endianness) -> Result<Vec<Self>> {
+        Ok(convert_bytes_to(vec, e))
+    }
+    fn from_raw<R: Read>(src: R, e: Endianness) -> Result<Self> {
+        e.read_u16(src).map_err(From::from)
+    }
+}
+impl DataElement for i16 {
+    type Transform = LinearTransformViaF32;
+    fn from_raw_vec(vec: Vec<u8>, e: Endianness) -> Result<Vec<Self>> {
+        Ok(convert_bytes_to(vec, e))
+    }
+    fn from_raw<R: Read>(src: R, e: Endianness) -> Result<Self> {
+        e.read_i16(src).map_err(From::from)
+    }
+}
+impl DataElement for u32 {
+    type Transform = LinearTransformViaF32;
+    fn from_raw_vec(vec: Vec<u8>, e: Endianness) -> Result<Vec<Self>> {
+        Ok(convert_bytes_to(vec, e))
+    }
+    fn from_raw<R: Read>(src: R, e: Endianness) -> Result<Self> {
+        e.read_u32(src).map_err(From::from)
+    }
+}
+impl DataElement for i32 {
+    type Transform = LinearTransformViaF32;
+    fn from_raw_vec(vec: Vec<u8>, e: Endianness) -> Result<Vec<Self>> {
+        Ok(convert_bytes_to(vec, e))
+    }
+    fn from_raw<R: Read>(src: R, e: Endianness) -> Result<Self> {
+        e.read_i32(src).map_err(From::from)
+    }
+}
+impl DataElement for u64 {
+    type Transform = LinearTransformViaF64;
+    fn from_raw_vec(vec: Vec<u8>, e: Endianness) -> Result<Vec<Self>> {
+        Ok(convert_bytes_to(vec, e))
+    }
+    fn from_raw<R: Read>(src: R, e: Endianness) -> Result<Self> {
+        e.read_u64(src).map_err(From::from)
+    }
+}
+impl DataElement for i64 {
+    type Transform = LinearTransformViaF64;
+    fn from_raw_vec(vec: Vec<u8>, e: Endianness) -> Result<Vec<Self>> {
+        Ok(convert_bytes_to(vec, e))
+    }
+    fn from_raw<R: Read>(src: R, e: Endianness) -> Result<Self> {
+        e.read_i64(src).map_err(From::from)
+    }
+}
+impl DataElement for f32 {
+    type Transform = LinearTransformViaOriginal;
+    fn from_raw_vec(vec: Vec<u8>, e: Endianness) -> Result<Vec<Self>> {
+        Ok(convert_bytes_to(vec, e))
+    }
+    fn from_raw<R: Read>(src: R, e: Endianness) -> Result<Self> {
+        e.read_f32(src).map_err(From::from)
+    }
+}
+impl DataElement for f64 {
+    type Transform = LinearTransformViaOriginal;
+    fn from_raw_vec(vec: Vec<u8>, e: Endianness) -> Result<Vec<Self>> {
+        Ok(convert_bytes_to(vec, e))
+    }
+    fn from_raw<R: Read>(src: R, e: Endianness) -> Result<Self> {
+        e.read_f64(src).map_err(From::from)
+    }
+}

--- a/src/volume/mod.rs
+++ b/src/volume/mod.rs
@@ -6,7 +6,9 @@
 //! to this crate.
 
 pub mod inmem;
+pub mod element;
 pub use self::inmem::*;
+
 mod util;
 use error::{NiftiError, Result};
 use typedef::NiftiType;

--- a/src/volume/ndarray.rs
+++ b/src/volume/ndarray.rs
@@ -1,23 +1,29 @@
 //! Interfaces and implementations specific to integration with `ndarray`
-use asprim::AsPrim;
 use ndarray::{Array, Axis, Ix, IxDyn};
 use volume::NiftiVolume;
 use std::ops::{Add, Mul};
-use num::Num;
+use num_traits::AsPrimitive;
 use error::Result;
-use safe_transmute::PodTransmutable;
+use volume::element::DataElement;
 
 /// Trait for volumes which can be converted to an ndarray.
 pub trait IntoNdArray {
     /// Consume the volume into an ndarray.
     fn to_ndarray<T>(self) -> Result<Array<T, IxDyn>>
     where
-        T: AsPrim,
-        T: Clone,
-        T: Num,
         T: Mul<Output = T>,
         T: Add<Output = T>,
-        T: PodTransmutable;
+        T: DataElement,
+        u8: AsPrimitive<T>,
+        i8: AsPrimitive<T>,
+        u16: AsPrimitive<T>,
+        i16: AsPrimitive<T>,
+        u32: AsPrimitive<T>,
+        i32: AsPrimitive<T>,
+        u64: AsPrimitive<T>,
+        i64: AsPrimitive<T>,
+        f32: AsPrimitive<T>,
+        f64: AsPrimitive<T>;
 }
 
 impl<V> IntoNdArray for super::SliceView<V>
@@ -26,12 +32,19 @@ where
 {
     fn to_ndarray<T>(self) -> Result<Array<T, IxDyn>>
     where
-        T: AsPrim,
-        T: Clone,
-        T: Num,
         T: Mul<Output = T>,
         T: Add<Output = T>,
-        T: PodTransmutable
+        T: DataElement,
+        u8: AsPrimitive<T>,
+        i8: AsPrimitive<T>,
+        u16: AsPrimitive<T>,
+        i16: AsPrimitive<T>,
+        u32: AsPrimitive<T>,
+        i32: AsPrimitive<T>,
+        u64: AsPrimitive<T>,
+        i64: AsPrimitive<T>,
+        f32: AsPrimitive<T>,
+        f64: AsPrimitive<T>,
     {
         // TODO optimize this implementation (we don't need the whole volume)
         let volume = self.volume.to_ndarray()?;

--- a/src/volume/util.rs
+++ b/src/volume/util.rs
@@ -1,6 +1,6 @@
 //! Miscellaneous volume-related functions
 use error::{NiftiError, Result};
-use num::Zero;
+use num_traits::Zero;
 
 pub fn hot_vector<T>(dim: usize, axis: usize, value: T) -> Vec<T>
 where

--- a/tests/volume.rs
+++ b/tests/volume.rs
@@ -1,4 +1,3 @@
-extern crate asprim;
 extern crate flate2;
 extern crate nifti;
 #[macro_use]
@@ -10,7 +9,7 @@ extern crate approx;
 #[cfg(feature = "ndarray_volumes")]
 extern crate ndarray;
 #[cfg(feature = "ndarray_volumes")]
-extern crate num;
+extern crate num_traits;
 #[cfg(feature = "ndarray_volumes")]
 extern crate safe_transmute;
 
@@ -55,13 +54,12 @@ fn minimal_img_gz() {
 
 #[cfg(feature = "ndarray_volumes")]
 mod ndarray_volumes {
-    use asprim::AsPrim;
-    use nifti::{Endianness, InMemNiftiObject, InMemNiftiVolume, NiftiHeader, NiftiObject,
-                NiftiVolume, NiftiType, IntoNdArray};
+    use std::fmt;
+    use std::ops::{Add, Mul};
+    use nifti::{DataElement, Endianness, InMemNiftiObject, InMemNiftiVolume,
+                NiftiHeader, NiftiObject, NiftiVolume, NiftiType, IntoNdArray};
     use ndarray::{Array, Axis, IxDyn, ShapeBuilder};
-    use num::traits::{Num};
-    use safe_transmute::PodTransmutable;
-    use std;
+    use num_traits::AsPrimitive;
 
     #[test]
     fn minimal_img_gz_ndarray_f32() {
@@ -256,7 +254,23 @@ mod ndarray_volumes {
     }
 
     fn test_types<T>(path: &str, dtype: NiftiType)
-        where T: AsPrim + Num + PodTransmutable + std::fmt::Debug
+        where
+            T: fmt::Debug,
+            T: Add<Output = T>,
+            T: Mul<Output = T>,
+            T: DataElement,
+            T: PartialEq<T>,
+            u8: AsPrimitive<T>,
+            i8: AsPrimitive<T>,
+            u16: AsPrimitive<T>,
+            i16: AsPrimitive<T>,
+            u32: AsPrimitive<T>,
+            i32: AsPrimitive<T>,
+            u64: AsPrimitive<T>,
+            i64: AsPrimitive<T>,
+            f32: AsPrimitive<T>,
+            f64: AsPrimitive<T>,
+            usize: AsPrimitive<T>,
     {
         let volume = InMemNiftiObject::from_file(path)
             .expect("Can't read input file.")
@@ -265,7 +279,7 @@ mod ndarray_volumes {
 
         let data = volume.to_ndarray::<T>().unwrap();
         for (idx, val) in data.iter().enumerate() {
-            assert_eq!(idx.as_::<T>(), *val);
+            assert_eq!(idx.as_(), *val);
         }
     }
 }


### PR DESCRIPTION
This is a change that I had predicted while discussing #5. This adds a new API for low-level reading and manipulation of data elements in a volume. It will play a more important role in the `IntoNdArray` API, because this replaces the previous constraints into new ones. `PodTransmutable` is no longer needed as part of the public API, but is still used underneath.
The new `DataElement` trait has been manually implemented for each type to ensure the most appropriate reading and transformation procedures. The new `LinearTransform` trait also sets a backbone for potential optimizations in the future, as it enables the `v * slope + intercept` operation to be performed at a large scale.

I will leave it here for a few days for potential feedback, until I merge and release. @nilgoyette your feedback would be much appreciated. :slightly_smiling_face: