### PR TITLE
Use 'c' order instead of 'fortran' order when creating ndarray

### DIFF
--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -210,8 +210,7 @@ impl InMemNiftiVolume {
         let mut data: Vec<O> = data.into_iter().map(AsPrimitive::as_).collect();
         <O as DataElement>::Transform::linear_transform_many_inline(&mut data, self.scl_slope, self.scl_inter);
 
-        Ok(Array::from_shape_vec(IxDyn(&dim).f(), data)
-            .expect("Inconsistent raw data size"))
+        Ok(Array::from_shape_vec(IxDyn(&dim), data).expect("Inconsistent raw data size"))
     }
 }
 


### PR DESCRIPTION
We are currently using 'fortran' order (column major) when converting the volume to a dynamic ndarray. This is working perfectly but a majority of users probably prefers 'c' order (row major).

All tests still pass. I wasn't sure if I needed to add a new one. I decided not to because 1) it's supposed to be transparent to the user 2) I'm not sure what to test. a pointer greater than another pointer?