### PR TITLE
Improve documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,9 @@
 //! # }
 //! ```
 //!
-//! You can also convert a volume to an [`ndarray::Array`](https://docs.rs/ndarray)
-//! and work from there:
+//! With the `ndarray_volumes` Cargo feature enabled, you can also convert a
+//! volume to an [`ndarray::Array`](https://docs.rs/ndarray) and work from
+//! there:
 //!
 //! ```no_run
 //! # #[cfg(feature = "ndarray_volumes")]

--- a/src/volume/element.rs
+++ b/src/volume/element.rs
@@ -11,8 +11,11 @@ use num_traits::cast::AsPrimitive;
 use util::{Endianness, convert_bytes_to};
 
 /// Interface for linear (affine) transformations to values. Multiple
-/// implementations are needed because the original type `T` may not
-/// have enough precision to obtain an appropriate outcome.
+/// implementations are needed because the original type `T` may not have
+/// enough precision to obtain an appropriate outcome. For example,
+/// transforming a `u8` is always done through `f32`, but an `f64` is instead
+/// manipulated through its own type by first converting the slope and
+/// intercept arguments to `f64`.
 pub trait LinearTransform<T: 'static + Copy> {
     /// Linearly transform a value with the given slope and intercept.
     fn linear_transform(value: T, slope: f32, intercept: f32) -> T;
@@ -88,7 +91,9 @@ where
     }
 }
 
-/// Trait type for characterizing a NIfTI data element.
+/// Trait type for characterizing a NIfTI data element, implemented for
+/// primitive numeric types which are used by the crate to represent voxel
+/// values.
 pub trait DataElement: 'static + Sized + Copy + AsPrimitive<u8> + AsPrimitive<f32> + AsPrimitive<f64>
 {
     /// For defining how this element is linearly transformed to another.

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -21,11 +21,16 @@ use volume::ndarray::IntoNdArray;
 #[cfg(feature = "ndarray_volumes")]
 use ndarray::{Array, Ix, IxDyn, ShapeBuilder};
 
-/// A data type for a NIFTI-1 volume contained in memory.
-/// Objects of this type contain raw image data, which
-/// is converted automatically when using reading methods
-/// or converting it to an `ndarray` (with the
-/// `ndarray_volumes` feature).
+/// A data type for a NIFTI-1 volume contained in memory. Objects of this type
+/// contain raw image data, which is converted automatically when using reading
+/// methods or [converting it to an `ndarray`] (only with the `ndarray_volumes`
+/// feature).
+/// 
+/// Since NIfTI volumes are stored in disk in column major order (also called
+/// Fortran order), this data type will also retain this memory order.
+/// 
+/// [converting it to an `ndarray`]: ../ndarray/index.html
+/// 
 #[derive(Debug, PartialEq, Clone)]
 pub struct InMemNiftiVolume {
     dim: [u16; 8],

--- a/src/volume/ndarray.rs
+++ b/src/volume/ndarray.rs
@@ -1,14 +1,43 @@
-//! Interfaces and implementations specific to integration with `ndarray`
-use ndarray::{Array, Axis, Ix, IxDyn};
-use volume::NiftiVolume;
-use std::ops::{Add, Mul};
-use num_traits::AsPrimitive;
+//! Interfaces and implementations specific to integration with `ndarray`.
+//!
+//! This module introduces the trait [`IntoNdArray`], which is implemented for
+//! all NIfTI volume types and enable their mapping into an [`Array`] with a
+//! dynamic number of dimensions and an abitrary element type. The affine
+//! scaling of the values (from the `scl_slope` and `scl_inter` attributes) are
+//! also considered in this transformation.
+//! 
+//! A target [element type] needs to be provided at compile time, which is
+//! usually the data type that the user wishes to work the array with. If the
+//! source and target types do not match, each voxel is cast in a way as to
+//! avoid loss of precision.
+//!
+//! #### Note on memory order
+//! 
+//! NIfTI volumes are usually stored in disk in column major order (also called
+//! Fortran order). As such, the array resulting from this operation will also 
+//! be in this memory order, rather than the usual row major order (AKA C
+//! ordering). When accessing the array, one should consider any potential
+//! bottlenecks emerging from this ordering in their data processing pipelines.
+//! Namely, it might be faster to produce output arrays in column major order
+//! as well.
+//! 
+//! [`IntoNdArray`]: ./trait.IntoNdArray.html
+//! [`Array`]: ../../../ndarray/type.Array.html
+//! [element type]: ../element/trait.DataElement.html
+//!
 use error::Result;
+use ndarray::{Array, Axis, Ix, IxDyn};
+use num_traits::AsPrimitive;
+use std::ops::{Add, Mul};
 use volume::element::DataElement;
+use volume::NiftiVolume;
 
 /// Trait for volumes which can be converted to an ndarray.
+///
+/// Please see the [module-level documentation](index.html) for more details.
 pub trait IntoNdArray {
-    /// Consume the volume into an ndarray.
+    /// Consume the volume into an ndarray with the same number of dimensions
+    /// and the given target element type `T`.
     fn to_ndarray<T>(self) -> Result<Array<T, IxDyn>>
     where
         T: Mul<Output = T>,


### PR DESCRIPTION
- Mention `ndarray_volumes` feature in lib.rs
- Explain `LinearTransform` a bit more
- Expand `InMemNiftiVolume` docs on `ndarray` and array memory order
- Significantly expand documentation in `volume::ndarray` module
- rustfmt ndarray.rs