### PR TITLE
Update ndarray dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ safe-transmute = "0.8.0"
 
 [dependencies.ndarray]
 optional = true
-version = "0.12"
+version = ">=0.10.12,<0.13.0"
 
 [dev-dependencies]
 approx = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ safe-transmute = "0.8.0"
 
 [dependencies.ndarray]
 optional = true
-version = ">=0.10.12,<0.12.0"
+version = "0.12"
 
 [dev-dependencies]
 approx = "0.3.0"


### PR DESCRIPTION
Update to ndarray 0.12.

Tested with and without `--features ndarray_volumes`. I'm not sure if you wanted a "strange" version like `">=0.10.12,<0.13.0"`?