### PR TITLE
Move endianness info to NiftiHeader

### DIFF
--- a/examples/niftidump/main.rs
+++ b/examples/niftidump/main.rs
@@ -9,7 +9,6 @@ fn main() {
     let mut args = env::args().skip(1);
     let filename = args.next().expect("Path to NIFTI file is required");
     let header = NiftiHeader::from_file(filename)
-        .expect("Failed to read NIFTI file")
-        .0;
+        .expect("Failed to read NIFTI file");
     println!("{:#?}", &header);
 }

--- a/tests/header.rs
+++ b/tests/header.rs
@@ -17,14 +17,14 @@ fn minimal_hdr() {
         scl_slope: 0.,
         scl_inter: 0.,
         magic: *b"ni1\0",
+        endianness: Endianness::BE,
         ..Default::default()
     };
 
     const FILE_NAME: &str = "resources/minimal.hdr";
-    let (h, e) = NiftiHeader::from_file(FILE_NAME).unwrap();
+    let header = NiftiHeader::from_file(FILE_NAME).unwrap();
     
-    assert_eq!(h, minimal_hdr);
-    assert_eq!(e, Endianness::BE);
+    assert_eq!(header, minimal_hdr);
 }
 
 #[test]
@@ -39,14 +39,14 @@ fn minimal_hdr_gz() {
         scl_slope: 0.,
         scl_inter: 0.,
         magic: *b"ni1\0",
+        endianness: Endianness::BE,
         ..Default::default()
     };
 
     const FILE_NAME: &str = "resources/minimal.hdr.gz";
-    let (h, e) = NiftiHeader::from_file(FILE_NAME).unwrap();
+    let header = NiftiHeader::from_file(FILE_NAME).unwrap();
     
-    assert_eq!(h, minimal_hdr);
-    assert_eq!(e, Endianness::BE);
+    assert_eq!(header, minimal_hdr);
 }
 
 #[test]
@@ -61,15 +61,16 @@ fn minimal_nii() {
         scl_slope: 0.,
         scl_inter: 0.,
         magic: *b"n+1\0",
+        endianness: Endianness::BE,
         ..Default::default()
     };
 
     const FILE_NAME: &str = "resources/minimal.nii";
     let file = File::open(FILE_NAME).unwrap();
-    let (h, e) = NiftiHeader::from_stream(file).unwrap();
+    let header = NiftiHeader::from_stream(file).unwrap();
     
-    assert_eq!(h, minimal_hdr);
-    assert_eq!(e, Endianness::BE);
+    assert_eq!(header, minimal_hdr);
+    assert_eq!(header.endianness, Endianness::BE);
 }
 
 #[test]
@@ -101,14 +102,15 @@ fn avg152T1_LR_hdr_gz() {
         srow_y: [0., 2., 0., -126.],
         srow_z: [0., 0., 2., -72.],
         magic: *b"ni1\0",
+        endianness: Endianness::BE,
         ..Default::default()
     };
 
     const FILE_NAME: &str = "resources/avg152T1_LR_nifti.hdr.gz";
-    let (h, e) = NiftiHeader::from_file(FILE_NAME).unwrap();
+    let header = NiftiHeader::from_file(FILE_NAME).unwrap();
     
-    assert_eq!(h, avg152t1_lr_hdr);
-    assert_eq!(e, Endianness::BE);
+    assert_eq!(header, avg152t1_lr_hdr);
+    assert_eq!(header.endianness, Endianness::BE);
 }
 
 #[test]
@@ -140,14 +142,14 @@ fn avg152T1_LR_nii_gz() {
         srow_y: [0., 2., 0., -126.],
         srow_z: [0., 0., 2., -72.],
         magic: *b"n+1\0",
+        endianness: Endianness::BE,
         ..Default::default()
     };
 
     const FILE_NAME: &str = "resources/avg152T1_LR_nifti.nii.gz";
-    let (h, e) = NiftiHeader::from_file(FILE_NAME).unwrap();
+    let header = NiftiHeader::from_file(FILE_NAME).unwrap();
     
-    assert_eq!(h, avg152t1_lr_hdr);
-    assert_eq!(e, Endianness::BE);
+    assert_eq!(header, avg152t1_lr_hdr);
 }
 
 #[test]
@@ -175,12 +177,12 @@ fn zstat1_nii_gz() {
         quatern_b: 0.,
         quatern_c: 1.,
         magic: *b"n+1\0",
+        endianness: Endianness::BE,
         ..Default::default()
     };
 
     const FILE_NAME: &str = "resources/zstat1.nii.gz";
-    let (h, e) = NiftiHeader::from_file(FILE_NAME).unwrap();
+    let header = NiftiHeader::from_file(FILE_NAME).unwrap();
     
-    assert_eq!(h, zstat1_hdr);
-    assert_eq!(e, Endianness::BE);
+    assert_eq!(header, zstat1_hdr);
 }

--- a/tests/object.rs
+++ b/tests/object.rs
@@ -5,7 +5,7 @@ extern crate nifti;
 #[macro_use]
 extern crate pretty_assertions;
 
-use nifti::{InMemNiftiObject, NiftiHeader, NiftiObject, NiftiType, NiftiVolume};
+use nifti::{Endianness, InMemNiftiObject, NiftiHeader, NiftiObject, NiftiType, NiftiVolume};
 
 #[test]
 fn minimal_nii_gz() {
@@ -19,6 +19,7 @@ fn minimal_nii_gz() {
         scl_slope: 0.,
         scl_inter: 0.,
         magic: *b"n+1\0",
+        endianness: Endianness::BE,
         ..Default::default()
     };
 
@@ -42,6 +43,7 @@ fn minimal_nii() {
         scl_slope: 0.,
         scl_inter: 0.,
         magic: *b"n+1\0",
+        endianness: Endianness::BE,
         ..Default::default()
     };
 
@@ -65,6 +67,7 @@ fn minimal_by_hdr() {
         scl_slope: 0.,
         scl_inter: 0.,
         magic: *b"ni1\0",
+        endianness: Endianness::BE,
         ..Default::default()
     };
 
@@ -89,6 +92,7 @@ fn minimal_by_hdr_and_img_gz() {
         scl_slope: 0.,
         scl_inter: 0.,
         magic: *b"ni1\0",
+        endianness: Endianness::BE,
         ..Default::default()
     };
 
@@ -113,6 +117,7 @@ fn minimal_by_hdr_gz() {
         scl_slope: 0.,
         scl_inter: 0.,
         magic: *b"ni1\0",
+        endianness: Endianness::BE,
         ..Default::default()
     };
 
@@ -136,6 +141,7 @@ fn minimal_by_pair() {
         scl_slope: 0.,
         scl_inter: 0.,
         magic: *b"ni1\0",
+        endianness: Endianness::BE,
         ..Default::default()
     };
 
@@ -164,6 +170,7 @@ fn f32_nii_gz() {
         srow_z: [0., 0., 1., 0.],
         sform_code: 2,
         magic: *b"n+1\0",
+        endianness: Endianness::LE,
         ..Default::default()
     };
 

--- a/tests/volume.rs
+++ b/tests/volume.rs
@@ -27,11 +27,12 @@ fn minimal_img_gz() {
         scl_slope: 0.,
         scl_inter: 0.,
         magic: *b"ni1\0",
+        endianness: Endianness::BE,
         ..Default::default()
     };
 
     const FILE_NAME: &str = "resources/minimal.img.gz";
-    let volume = InMemNiftiVolume::from_file(FILE_NAME, &minimal_hdr, Endianness::BE).unwrap();
+    let volume = InMemNiftiVolume::from_file(FILE_NAME, &minimal_hdr).unwrap();
 
     assert_eq!(volume.dim(), [64, 64, 10].as_ref());
 
@@ -73,11 +74,12 @@ mod ndarray_volumes {
             scl_slope: 0.,
             scl_inter: 0.,
             magic: *b"ni1\0",
+            endianness: Endianness::BE,
             ..Default::default()
         };
 
         const FILE_NAME: &str = "resources/minimal.img.gz";
-        let volume = InMemNiftiVolume::from_file(FILE_NAME, &minimal_hdr, Endianness::BE).unwrap();
+        let volume = InMemNiftiVolume::from_file(FILE_NAME, &minimal_hdr).unwrap();
 
         assert_eq!(volume.dim(), [64, 64, 10].as_ref());
 
@@ -110,11 +112,12 @@ mod ndarray_volumes {
             scl_slope: 0.,
             scl_inter: 0.,
             magic: *b"ni1\0",
+            endianness: Endianness::BE,
             ..Default::default()
         };
 
         const FILE_NAME: &str = "resources/minimal.img.gz";
-        let volume = InMemNiftiVolume::from_file(FILE_NAME, &minimal_hdr, Endianness::BE).unwrap();
+        let volume = InMemNiftiVolume::from_file(FILE_NAME, &minimal_hdr).unwrap();
         assert_eq!(volume.data_type(), NiftiType::Uint8);
         assert_eq!(volume.dim(), [64, 64, 10].as_ref());
 


### PR DESCRIPTION
This PR changes `NiftiHeader` so that it contains an extra `endianness` member containing the byte order of the originally read file. When building a new header, the system's native endianness will be the default. Moreover, the respective constructors will no longer yield a `(header, endianness)` pair:

```rust
// before
pub fn from_file<P: AsRef<Path>>(path: P) -> Result<(NiftiHeader, Endianness)> { ... }
// after
pub fn from_file<P: AsRef<Path>>(path: P) -> Result<NiftiHeader> { ... }
```

This is a design decision that has kept in my mind for a while, but now I honestly believe it's worth the breaking change, for the following reasons:

- It is unconventional to see constructors such as `from_stream` and `from_file` to return a tuple rather than just `Self` or `Result<Self>`.
- Returning a tuple makes these functions more complicated to work with.
- The header's byte order is an inherent property materialized in how the contents were written to disk, and that property is lost in the current reading process (which harmonizes all attributes to native byte order).
- `NiftiHeader` does not have a native memory representation anyway. The `descrip` member was already put into a `Vec<u8>` (arrays larger than 32 are currently bad to work with), so one shouldn't be relying on this type to be a memory equivalent of the respective C-like struct. Adding an extra member is not a problem in this regard.
- And finally, those focused on using the `NiftiObject` API shouldn't notice a difference.