### PR TITLE
InMemNiftiVolume::from_raw_data

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -47,8 +47,8 @@ quick_error! {
             cause(err)
             description(err.description())
         }
-        /// Raw data and buffer length incompatible
-        IncompatibleLengthError {
+        /// Raw data and buffer length are incompatible
+        IncompatibleLength {
             description("The buffer length and the header dimensions are incompatible.")
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,7 +47,10 @@ quick_error! {
             cause(err)
             description(err.description())
         }
-
+        /// Raw data and buffer length incompatible
+        IncompatibleLengthError {
+            description("The buffer length and the header dimensions are incompatible.")
+        }
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,6 +6,8 @@ use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
 
 use safe_transmute::{guarded_transmute_pod_vec_permissive, PodTransmutable};
 
+use NiftiHeader;
+
 /// A trait that is both Read and Seek.
 pub trait ReadSeek: Read + Seek {}
 impl<T: Read + Seek> ReadSeek for T {}
@@ -160,6 +162,15 @@ pub fn convert_bytes_to<T: PodTransmutable>(mut a: Vec<u8>, e: Endianness) -> Ve
     }
 
     guarded_transmute_pod_vec_permissive(a)
+}
+
+pub fn nb_bytes_for_data(header: &NiftiHeader) -> usize {
+    let ndims = header.dim[0];
+    let resolution: usize = header.dim[1..(ndims + 1) as usize]
+        .iter()
+        .map(|d| *d as usize)
+        .product();
+    resolution * header.bitpix as usize / 8
 }
 
 pub fn is_gz_file<P: AsRef<Path>>(path: P) -> bool {

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -46,7 +46,7 @@ impl InMemNiftiVolume {
     /// declared in the header are expected to fit.
     pub fn from_raw_data(header: &NiftiHeader, raw_data: Vec<u8>) -> Result<Self> {
         if nb_bytes_for_data(header) != raw_data.len() {
-            return Err(NiftiError::IncompatibleLengthError);
+            return Err(NiftiError::IncompatibleLength);
         }
 
         let datatype: NiftiType =

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -42,7 +42,7 @@ pub struct InMemNiftiVolume {
 }
 
 impl InMemNiftiVolume {
-    /// Build a InMemNiftiVolume from a header and a buffer. The buffer length and the dimensions
+    /// Build an InMemNiftiVolume from a header and a buffer. The buffer length and the dimensions
     /// declared in the header are expected to fit.
     pub fn from_raw_data(header: &NiftiHeader, raw_data: Vec<u8>) -> Result<Self> {
         assert!(nb_bytes_for_data(header) == raw_data.len(),

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -45,8 +45,10 @@ impl InMemNiftiVolume {
     /// Build an InMemNiftiVolume from a header and a buffer. The buffer length and the dimensions
     /// declared in the header are expected to fit.
     pub fn from_raw_data(header: &NiftiHeader, raw_data: Vec<u8>) -> Result<Self> {
-        assert!(nb_bytes_for_data(header) == raw_data.len(),
-            "The buffer length and the header dimensions are incompatible.");
+        if nb_bytes_for_data(header) != raw_data.len() {
+            return Err(NiftiError::IncompatibleLengthError);
+        }
+
         let datatype: NiftiType =
             NiftiType::from_i16(header.datatype).ok_or_else(|| NiftiError::InvalidFormat)?;
         Ok(InMemNiftiVolume {

--- a/tests/object.rs
+++ b/tests/object.rs
@@ -187,3 +187,31 @@ fn f32_nii_gz() {
     assert_eq!(volume.get_f32(&[5, 0, 4]).unwrap(), 0.4);
     assert_eq!(volume.get_f32(&[0, 8, 5]).unwrap(), 0.8);
 }
+
+#[cfg(feature = "ndarray_volumes")]
+#[test]
+fn test_false_4d() {
+    use ndarray::Ix3;
+    use nifti:: {InMemNiftiVolume, IntoNdArray};
+
+    let (w, h, d) = (5, 5, 5);
+    let mut header = NiftiHeader {
+        dim: [4, w, h, d, 1, 1, 1, 1],
+        datatype: 2,
+        bitpix: 8,
+        ..Default::default()
+    };
+    let raw_data = vec![0; (w * h * d) as usize];
+    let mut volume = InMemNiftiVolume::from_raw_data(&header, raw_data).unwrap();
+    assert_eq!(header.dim[0], 4);
+    assert_eq!(volume.dimensionality(), 4);
+    if header.dim[header.dim[0] as usize] == 1 {
+        header.dim[0] -= 1;
+        volume = InMemNiftiVolume::from_raw_data(&header, volume.to_raw_data()).unwrap();
+    }
+    assert_eq!(volume.dimensionality(), 3);
+    let dyn_data = volume.to_ndarray::<f32>().unwrap();
+    assert_eq!(dyn_data.ndim(), 3);
+    let data = dyn_data.into_dimensionality::<Ix3>().unwrap();
+    assert_eq!(data.ndim(), 3); // Obvious, but it's to avoid being optimized away
+}

--- a/tests/object.rs
+++ b/tests/object.rs
@@ -187,31 +187,3 @@ fn f32_nii_gz() {
     assert_eq!(volume.get_f32(&[5, 0, 4]).unwrap(), 0.4);
     assert_eq!(volume.get_f32(&[0, 8, 5]).unwrap(), 0.8);
 }
-
-#[cfg(feature = "ndarray_volumes")]
-#[test]
-fn test_false_4d() {
-    use ndarray::Ix3;
-    use nifti:: {InMemNiftiVolume, IntoNdArray};
-
-    let (w, h, d) = (5, 5, 5);
-    let mut header = NiftiHeader {
-        dim: [4, w, h, d, 1, 1, 1, 1],
-        datatype: 2,
-        bitpix: 8,
-        ..Default::default()
-    };
-    let raw_data = vec![0; (w * h * d) as usize];
-    let mut volume = InMemNiftiVolume::from_raw_data(&header, raw_data).unwrap();
-    assert_eq!(header.dim[0], 4);
-    assert_eq!(volume.dimensionality(), 4);
-    if header.dim[header.dim[0] as usize] == 1 {
-        header.dim[0] -= 1;
-        volume = InMemNiftiVolume::from_raw_data(&header, volume.to_raw_data()).unwrap();
-    }
-    assert_eq!(volume.dimensionality(), 3);
-    let dyn_data = volume.to_ndarray::<f32>().unwrap();
-    assert_eq!(dyn_data.ndim(), 3);
-    let data = dyn_data.into_dimensionality::<Ix3>().unwrap();
-    assert_eq!(data.ndim(), 3); // Obvious, but it's to avoid being optimized away
-}

--- a/tests/object.rs
+++ b/tests/object.rs
@@ -79,7 +79,6 @@ fn minimal_by_hdr() {
     assert_eq!(volume.dim(), [64, 64, 10].as_ref());
 }
 
-
 #[test]
 fn minimal_by_hdr_and_img_gz() {
     let minimal_hdr = NiftiHeader {


### PR DESCRIPTION
Usage would look like:

    let mut header = obj.header().clone();
    let mut volume = obj.into_volume();
    // modify something in header, like dim, or modify raw_data, but it's a bad idea!
    volume = InMemNiftiVolume::from_raw_data(&header, volume.to_raw_data()).unwrap();

I did what I did because I only have a single use-case to consider. I'm not too sure about:

1. receiving a header. It seemed better than asking for `dim`, `datatype`, `scl_slope`, `scl_inter` and `endianness`, but it forces the programmer to create a header. I don't think it's a problem because it's easy to create one with `default` and the `..` syntax.
2. returning a Result. I don't like it, but I don't like asking for a `datatype` either.

I added **a test** for my "false 4D image" that I didn't push because I don't know if you want to have more toy images in your lib.