### PR TITLE
Improve function naming in volume-related functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ let obj = InMemNiftiObject::from_file("myvolume.hdr.gz")?;
 With the "ndarray_volumes" feature enabled, you can also convert a volume to an [`ndarray::Array`](https://docs.rs/ndarray/0.11.1/ndarray/index.html) and work from there:
 
 ```rust
-let volume = obj.into_volume().to_ndarray::<f32>();
+let volume = obj.into_volume().into_ndarray::<f32>();
 ```
 
 ## Roadmap

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //! # use nifti::{NiftiObject, InMemNiftiObject};
 //! use nifti::IntoNdArray;
 //! # let obj = InMemNiftiObject::from_file("myvolume.hdr.gz").unwrap();
-//! let volume = obj.into_volume().to_ndarray::<f32>()?;
+//! let volume = obj.into_volume().into_ndarray::<f32>()?;
 //! # Ok(())
 //! # }
 //! ```

--- a/src/object.rs
+++ b/src/object.rs
@@ -10,7 +10,7 @@ use header::NiftiHeader;
 use header::MAGIC_CODE_NI1;
 use volume::NiftiVolume;
 use volume::inmem::InMemNiftiVolume;
-use util::{is_gz_file, to_img_file_gz, Endianness};
+use util::{is_gz_file, into_img_file_gz, Endianness};
 use error::Result;
 use byteorder::{BigEndian, LittleEndian};
 use flate2::bufread::GzDecoder;
@@ -89,7 +89,7 @@ impl InMemNiftiObject {
 
             // look for corresponding img file
             let img_path = path.as_ref().to_path_buf();
-            let mut img_path_gz = to_img_file_gz(img_path);
+            let mut img_path_gz = into_img_file_gz(img_path);
 
             InMemNiftiVolume::from_file_with_extensions(&img_path_gz, &header, extender)
                 .or_else(|e| {

--- a/src/util.rs
+++ b/src/util.rs
@@ -186,7 +186,7 @@ pub fn is_gz_file<P: AsRef<Path>>(path: P) -> bool {
 /// # Panics
 /// Can panic if the given file path is not a valid path to a header file.
 /// If it doesn't panic in this case, the result might still not be correct.
-pub fn to_img_file_gz(path: PathBuf) -> PathBuf {
+pub fn into_img_file_gz(path: PathBuf) -> PathBuf {
     let gz = is_gz_file(&path);
     let fname = path.file_name().unwrap().to_owned();
     let fname = fname.to_string_lossy();
@@ -202,7 +202,7 @@ pub fn to_img_file_gz(path: PathBuf) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::Endianness;
-    use super::to_img_file_gz;
+    use super::into_img_file_gz;
     use super::is_gz_file;
     use std::path::PathBuf;
 
@@ -239,23 +239,23 @@ mod tests {
 
         assert!(!is_gz_file("/path/to/image.hdr"));
         assert_eq!(
-            to_img_file_gz(PathBuf::from("/path/to/image.hdr")),
+            into_img_file_gz(PathBuf::from("/path/to/image.hdr")),
             PathBuf::from("/path/to/image.img.gz")
         );
 
         assert!(is_gz_file("/path/to/image.hdr.gz"));
         assert_eq!(
-            to_img_file_gz(PathBuf::from("/path/to/image.hdr.gz")),
+            into_img_file_gz(PathBuf::from("/path/to/image.hdr.gz")),
             PathBuf::from("/path/to/image.img.gz")
         );
 
         assert_eq!(
-            to_img_file_gz(PathBuf::from("my_ct_scan.1.hdr.gz")),
+            into_img_file_gz(PathBuf::from("my_ct_scan.1.hdr.gz")),
             PathBuf::from("my_ct_scan.1.img.gz")
         );
 
         assert_eq!(
-            to_img_file_gz(PathBuf::from("../you.cant.fool.me.hdr.gz")),
+            into_img_file_gz(PathBuf::from("../you.cant.fool.me.hdr.gz")),
             PathBuf::from("../you.cant.fool.me.img.gz")
         );
     }

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -172,8 +172,20 @@ impl InMemNiftiVolume {
     }
 
     /// Retrieve a reference to the raw data.
+    #[deprecated(note = "unconventional naming, please use `raw_data` instead")]
+    pub fn get_raw_data(&self) -> &[u8] {
+        self.raw_data()
+    }
+
+    /// Retrieve a reference to the raw data.
     pub fn raw_data(&self) -> &[u8] {
         &self.raw_data
+    }
+
+    /// Retrieve a mutable reference to the raw data.
+    #[deprecated(note = "unconventional naming, please use `raw_data_mut` instead")]
+    pub fn get_raw_data_mut(&mut self) -> &mut [u8] {
+        self.raw_data_mut()
     }
 
     /// Retrieve a mutable reference to the raw data.

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -161,17 +161,23 @@ impl InMemNiftiVolume {
     }
 
     /// Retrieve the raw data, consuming the volume.
+    #[deprecated(since = "0.6.0", note = "naming was unconventional, please use `into_raw_data` instead")]
     pub fn to_raw_data(self) -> Vec<u8> {
+        self.into_raw_data()
+    }
+
+    /// Retrieve the raw data, consuming the volume.
+    pub fn into_raw_data(self) -> Vec<u8> {
         self.raw_data
     }
 
     /// Retrieve a reference to the raw data.
-    pub fn get_raw_data(&self) -> &[u8] {
+    pub fn raw_data(&self) -> &[u8] {
         &self.raw_data
     }
 
     /// Retrieve a mutable reference to the raw data.
-    pub fn get_raw_data_mut(&mut self) -> &mut [u8] {
+    pub fn raw_data_mut(&mut self) -> &mut [u8] {
         &mut self.raw_data
     }
 
@@ -231,7 +237,7 @@ impl InMemNiftiVolume {
 #[cfg(feature = "ndarray_volumes")]
 impl IntoNdArray for InMemNiftiVolume {
     /// Consume the volume into an ndarray.
-    fn to_ndarray<T>(self) -> Result<Array<T, IxDyn>>
+    fn into_ndarray<T>(self) -> Result<Array<T, IxDyn>>
     where
         T: DataElement,
         u8: AsPrimitive<T>,
@@ -270,7 +276,7 @@ impl IntoNdArray for InMemNiftiVolume {
 #[cfg(feature = "ndarray_volumes")]
 impl<'a> IntoNdArray for &'a InMemNiftiVolume {
     /// Create an ndarray from the given volume.
-    fn to_ndarray<T>(self) -> Result<Array<T, IxDyn>>
+    fn into_ndarray<T>(self) -> Result<Array<T, IxDyn>>
     where
         T: Mul<Output = T>,
         T: Add<Output = T>,
@@ -286,7 +292,7 @@ impl<'a> IntoNdArray for &'a InMemNiftiVolume {
         f32: AsPrimitive<T>,
         f64: AsPrimitive<T>,
     {
-        self.clone().to_ndarray()
+        self.clone().into_ndarray()
     }
 }
 
@@ -444,14 +450,14 @@ mod tests {
         assert_eq!(volume.dimensionality(), 4);
         if header.dim[header.dim[0] as usize] == 1 {
             header.dim[0] -= 1;
-            volume = InMemNiftiVolume::from_raw_data(&header, volume.to_raw_data()).unwrap();
+            volume = InMemNiftiVolume::from_raw_data(&header, volume.into_raw_data()).unwrap();
         }
         assert_eq!(volume.dimensionality(), 3);
 
         #[cfg(feature = "ndarray_volumes")] {
             use ndarray::Ix3;
 
-            let dyn_data = volume.to_ndarray::<f32>().unwrap();
+            let dyn_data = volume.into_ndarray::<f32>().unwrap();
             assert_eq!(dyn_data.ndim(), 3);
             let data = dyn_data.into_dimensionality::<Ix3>().unwrap();
             assert_eq!(data.ndim(), 3); // Obvious, but it's to avoid being optimized away

--- a/src/volume/ndarray.rs
+++ b/src/volume/ndarray.rs
@@ -5,22 +5,22 @@
 //! dynamic number of dimensions and an abitrary element type. The affine
 //! scaling of the values (from the `scl_slope` and `scl_inter` attributes) are
 //! also considered in this transformation.
-//! 
+//!
 //! A target [element type] needs to be provided at compile time, which is
 //! usually the data type that the user wishes to work the array with. If the
 //! source and target types do not match, each voxel is cast in a way as to
 //! avoid loss of precision.
 //!
 //! #### Note on memory order
-//! 
+//!
 //! NIfTI volumes are usually stored in disk in column major order (also called
-//! Fortran order). As such, the array resulting from this operation will also 
+//! Fortran order). As such, the array resulting from this operation will also
 //! be in this memory order, rather than the usual row major order (AKA C
 //! ordering). When accessing the array, one should consider any potential
 //! bottlenecks emerging from this ordering in their data processing pipelines.
 //! Namely, it might be faster to produce output arrays in column major order
 //! as well.
-//! 
+//!
 //! [`IntoNdArray`]: ./trait.IntoNdArray.html
 //! [`Array`]: ../../../ndarray/type.Array.html
 //! [element type]: ../element/trait.DataElement.html
@@ -38,7 +38,33 @@ use volume::NiftiVolume;
 pub trait IntoNdArray {
     /// Consume the volume into an ndarray with the same number of dimensions
     /// and the given target element type `T`.
+    #[deprecated(
+        since = "0.6.0",
+        note = "unconventional naming, please use/implement `into_ndarray` instead"
+    )]
     fn to_ndarray<T>(self) -> Result<Array<T, IxDyn>>
+    where
+        Self: Sized,
+        T: Mul<Output = T>,
+        T: Add<Output = T>,
+        T: DataElement,
+        u8: AsPrimitive<T>,
+        i8: AsPrimitive<T>,
+        u16: AsPrimitive<T>,
+        i16: AsPrimitive<T>,
+        u32: AsPrimitive<T>,
+        i32: AsPrimitive<T>,
+        u64: AsPrimitive<T>,
+        i64: AsPrimitive<T>,
+        f32: AsPrimitive<T>,
+        f64: AsPrimitive<T>,
+    {
+        self.into_ndarray::<T>()
+    }
+
+    /// Consume the volume into an ndarray with the same number of dimensions
+    /// and the given target element type `T`.
+    fn into_ndarray<T>(self) -> Result<Array<T, IxDyn>>
     where
         T: Mul<Output = T>,
         T: Add<Output = T>,
@@ -59,7 +85,7 @@ impl<V> IntoNdArray for super::SliceView<V>
 where
     V: NiftiVolume + IntoNdArray,
 {
-    fn to_ndarray<T>(self) -> Result<Array<T, IxDyn>>
+    fn into_ndarray<T>(self) -> Result<Array<T, IxDyn>>
     where
         T: Mul<Output = T>,
         T: Add<Output = T>,
@@ -76,7 +102,7 @@ where
         f64: AsPrimitive<T>,
     {
         // TODO optimize this implementation (we don't need the whole volume)
-        let volume = self.volume.to_ndarray()?;
+        let volume = self.volume.into_ndarray()?;
         Ok(volume.into_subview(Axis(self.axis as Ix), self.index as usize))
     }
 }

--- a/tests/volume.rs
+++ b/tests/volume.rs
@@ -83,7 +83,7 @@ mod ndarray_volumes {
 
         assert_eq!(volume.dim(), [64, 64, 10].as_ref());
 
-        let volume = volume.to_ndarray::<f32>().unwrap();
+        let volume = volume.into_ndarray::<f32>().unwrap();
 
         assert_eq!(volume.shape(), [64, 64, 10].as_ref());
 
@@ -121,7 +121,7 @@ mod ndarray_volumes {
         assert_eq!(volume.data_type(), NiftiType::Uint8);
         assert_eq!(volume.dim(), [64, 64, 10].as_ref());
 
-        let volume = volume.to_ndarray::<u8>().unwrap();
+        let volume = volume.into_ndarray::<u8>().unwrap();
 
         assert_eq!(volume.shape(), [64, 64, 10].as_ref());
 
@@ -146,7 +146,7 @@ mod ndarray_volumes {
             .into_volume();
         assert_eq!(volume.data_type(), NiftiType::Float32);
 
-        let volume = volume.to_ndarray::<f32>().unwrap();
+        let volume = volume.into_ndarray::<f32>().unwrap();
 
         assert_eq!(volume.shape(), [11, 11, 11].as_ref());
 
@@ -168,7 +168,7 @@ mod ndarray_volumes {
             .into_volume();
         assert_eq!(volume.data_type(), NiftiType::Float32);
 
-        let volume = volume.to_ndarray::<f64>().unwrap();
+        let volume = volume.into_ndarray::<f64>().unwrap();
 
         assert_eq!(volume.shape(), [11, 11, 11].as_ref());
 
@@ -280,7 +280,7 @@ mod ndarray_volumes {
             .into_volume();
         assert_eq!(volume.data_type(), dtype);
 
-        let data = volume.to_ndarray::<T>().unwrap();
+        let data = volume.into_ndarray::<T>().unwrap();
         for (idx, val) in data.iter().enumerate() {
             assert_eq!(idx.as_(), *val);
         }


### PR DESCRIPTION
The [naming guidelines](https://rust-lang-nursery.github.io/api-guidelines/naming.html) established in the Rust API guidelines help us create interfaces that are generally intuitive and non-confusing for the usual Rust programmer. During the development of `nifti`, I accidentally gave some methods and functions unconventional names, which I believe should be corrected before the crate enters a mature state. To make the migration process smoother, I deprecated the old methods for removal, starting from 0.6.0, and will only remove them in 0.7.0.

- deprecate `InMemNiftiVolume::to_raw_data` into `into_raw_data`
- deprecate `InMemNiftiVolume::get_raw_data` and `InMemNiftiVolume::get_raw_data_mut` into `InMemNiftiVolume::raw_data` and `InMemNiftiVolume::raw_data_mut`
- deprecate `IntoNdarray::to_ndarray` into `into_ndarray`
- rename util function `to_img_file_gz` to `into_img_file_gz`