### PR TITLE
Improve integration with code type definitions

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -51,6 +51,11 @@ quick_error! {
         IncompatibleLength {
             description("The buffer length and the header dimensions are incompatible.")
         }
+        /// Header contains a code which is not valid for the given attribute
+        InvalidCode(typename: &'static str, code: i16) {
+            description("invalid code")
+            display("invalid code `{}` for {}", code, typename)
+        }
     }
 }
 

--- a/src/typedef.rs
+++ b/src/typedef.rs
@@ -14,6 +14,7 @@ use num_traits::AsPrimitive;
 /// Data type for representing a NIFTI value type in a volume.
 /// Methods for reading values of that type from a source are also included.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, FromPrimitive)]
+#[repr(u16)]
 pub enum NiftiType {
     /// unsigned char.
     // NIFTI_TYPE_UINT8           2
@@ -67,9 +68,9 @@ pub enum NiftiType {
 
 impl NiftiType {
     /// Retrieve the size of an element of this data type, in bytes.
-    pub fn size_of(&self) -> usize {
+    pub fn size_of(self) -> usize {
         use NiftiType::*;
-        match *self {
+        match self {
             Int8 | Uint8 => 1,
             Int16 | Uint16 => 2,
             Rgb24 => 3,
@@ -84,7 +85,7 @@ impl NiftiType {
 impl NiftiType {
     /// Read a primitive voxel value from a source.
     pub fn read_primitive_value<S, T>(
-        &self,
+        self,
         source: S,
         endianness: Endianness,
         slope: f32,
@@ -106,7 +107,7 @@ impl NiftiType {
         f32: AsPrimitive<T>,
         f64: AsPrimitive<T>,
     {
-        match *self {
+        match self {
             NiftiType::Uint8 => {
                 let raw = u8::from_raw(source, endianness)?;
                 Ok(<u8 as DataElement>::Transform::linear_transform(raw.as_(), slope, inter))
@@ -148,13 +149,14 @@ impl NiftiType {
                 Ok(<f64 as DataElement>::Transform::linear_transform(raw.as_(), slope, inter))
             }
             // TODO add support for more data types
-            _ => Err(NiftiError::UnsupportedDataType(*self)),
+            _ => Err(NiftiError::UnsupportedDataType(self)),
         }
     }
 }
 
 /// An enum type which represents a unit type.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, FromPrimitive)]
+#[repr(u8)]
 pub enum Unit {
     /// NIFTI code for unspecified units.
     Unknown = 0,
@@ -183,6 +185,7 @@ pub enum Unit {
 
 /// An enum type for representing a NIFTI intent code.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, FromPrimitive)]
+#[repr(u16)]
 pub enum Intent {
     /// default: no intention is indicated in the header.
     None = 0,
@@ -373,14 +376,15 @@ pub enum Intent {
 }
 
 impl Intent {
-    /// Check whether this intent code are used for statistics.
-    pub fn is_statcode(&self) -> bool {
-        *self as i16 >= 2 && *self as i16 <= 24
+    /// Check whether this intent code is used for statistics.
+    pub fn is_statcode(self) -> bool {
+        self as i16 >= 2 && self as i16 <= 24
     }
 }
 
 /// An enum type for representing a NIFTI XForm.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, FromPrimitive)]
+#[repr(u16)]
 pub enum XForm {
     /// Arbitrary coordinates (Method 1).
     Unknown = 0,
@@ -398,6 +402,7 @@ pub enum XForm {
 
 /// An enum type for representing the slice order.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, FromPrimitive)]
+#[repr(u8)]
 pub enum SliceOrder {
     /// NIFTI_SLICE_UNKNOWN
     Unknown = 0,

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -14,7 +14,7 @@ use util::{Endianness, nb_bytes_for_data};
 use byteorder::{BigEndian, LittleEndian};
 use flate2::bufread::GzDecoder;
 use typedef::NiftiType;
-use num_traits::{AsPrimitive, FromPrimitive, Num};
+use num_traits::{AsPrimitive, Num};
 
 #[cfg(feature = "ndarray_volumes")]
 use volume::ndarray::IntoNdArray;
@@ -49,8 +49,7 @@ impl InMemNiftiVolume {
             return Err(NiftiError::IncompatibleLength);
         }
 
-        let datatype: NiftiType =
-            NiftiType::from_i16(header.datatype).ok_or_else(|| NiftiError::InvalidFormat)?;
+        let datatype = header.data_type()?;
         Ok(InMemNiftiVolume {
             dim: header.dim,
             datatype,
@@ -72,9 +71,7 @@ impl InMemNiftiVolume {
         let mut raw_data = vec![0u8; nb_bytes_for_data(header)];
         source.read_exact(&mut raw_data)?;
 
-        let datatype: NiftiType =
-            NiftiType::from_i16(header.datatype).ok_or_else(|| NiftiError::InvalidFormat)?;
-
+        let datatype = header.data_type()?;
         Ok(InMemNiftiVolume {
             dim: header.dim,
             datatype,

--- a/tests/header.rs
+++ b/tests/header.rs
@@ -2,8 +2,8 @@ extern crate nifti;
 #[macro_use]
 extern crate pretty_assertions;
 
+use nifti::{Endianness, Intent, NiftiHeader, NiftiType, SliceOrder, Unit, XForm};
 use std::fs::File;
-use nifti::{Endianness, NiftiHeader};
 
 #[test]
 fn minimal_hdr() {
@@ -23,8 +23,15 @@ fn minimal_hdr() {
 
     const FILE_NAME: &str = "resources/minimal.hdr";
     let header = NiftiHeader::from_file(FILE_NAME).unwrap();
-    
+
     assert_eq!(header, minimal_hdr);
+
+    assert_eq!(header.intent().unwrap(), Intent::None);
+    assert_eq!(header.data_type().unwrap(), NiftiType::Uint8);
+    assert_eq!(header.xyzt_units().unwrap(), (Unit::Unknown, Unit::Unknown));
+    assert_eq!(header.slice_order().unwrap(), SliceOrder::Unknown);
+    assert_eq!(header.qform().unwrap(), XForm::Unknown);
+    assert_eq!(header.sform().unwrap(), XForm::Unknown);
 }
 
 #[test]
@@ -45,8 +52,15 @@ fn minimal_hdr_gz() {
 
     const FILE_NAME: &str = "resources/minimal.hdr.gz";
     let header = NiftiHeader::from_file(FILE_NAME).unwrap();
-    
+
     assert_eq!(header, minimal_hdr);
+
+    assert_eq!(header.intent().unwrap(), Intent::None);
+    assert_eq!(header.data_type().unwrap(), NiftiType::Uint8);
+    assert_eq!(header.xyzt_units().unwrap(), (Unit::Unknown, Unit::Unknown));
+    assert_eq!(header.slice_order().unwrap(), SliceOrder::Unknown);
+    assert_eq!(header.qform().unwrap(), XForm::Unknown);
+    assert_eq!(header.sform().unwrap(), XForm::Unknown);
 }
 
 #[test]
@@ -68,9 +82,16 @@ fn minimal_nii() {
     const FILE_NAME: &str = "resources/minimal.nii";
     let file = File::open(FILE_NAME).unwrap();
     let header = NiftiHeader::from_stream(file).unwrap();
-    
+
     assert_eq!(header, minimal_hdr);
     assert_eq!(header.endianness, Endianness::BE);
+
+    assert_eq!(header.intent().unwrap(), Intent::None);
+    assert_eq!(header.data_type().unwrap(), NiftiType::Uint8);
+    assert_eq!(header.xyzt_units().unwrap(), (Unit::Unknown, Unit::Unknown));
+    assert_eq!(header.slice_order().unwrap(), SliceOrder::Unknown);
+    assert_eq!(header.qform().unwrap(), XForm::Unknown);
+    assert_eq!(header.sform().unwrap(), XForm::Unknown);
 }
 
 #[test]
@@ -93,9 +114,10 @@ fn avg152T1_LR_hdr_gz() {
         cal_max: 255.,
         cal_min: 0.,
         descrip,
-        aux_file: [b'n', b'o', b'n', b'e',
-            b' ', b' ', b' ', b' ', b' ', b' ', b' ', b' ', b' ', b' ',
-            b' ', b' ', b' ', b' ', b' ', b' ', b' ', b' ', b' ', 0],
+        aux_file: [
+            b'n', b'o', b'n', b'e', b' ', b' ', b' ', b' ', b' ', b' ', b' ', b' ', b' ', b' ',
+            b' ', b' ', b' ', b' ', b' ', b' ', b' ', b' ', b' ', 0,
+        ],
         qform_code: 0,
         sform_code: 4,
         srow_x: [-2., 0., 0., 90.],
@@ -108,9 +130,16 @@ fn avg152T1_LR_hdr_gz() {
 
     const FILE_NAME: &str = "resources/avg152T1_LR_nifti.hdr.gz";
     let header = NiftiHeader::from_file(FILE_NAME).unwrap();
-    
+
     assert_eq!(header, avg152t1_lr_hdr);
     assert_eq!(header.endianness, Endianness::BE);
+
+    assert_eq!(header.intent().unwrap(), Intent::None);
+    assert_eq!(header.data_type().unwrap(), NiftiType::Uint8);
+    assert_eq!(header.xyzt_units().unwrap(), (Unit::Mm, Unit::Sec));
+    assert_eq!(header.slice_order().unwrap(), SliceOrder::Unknown);
+    assert_eq!(header.qform().unwrap(), XForm::Unknown);
+    assert_eq!(header.sform().unwrap(), XForm::Mni152);
 }
 
 #[test]
@@ -133,9 +162,10 @@ fn avg152T1_LR_nii_gz() {
         cal_max: 255.,
         cal_min: 0.,
         descrip,
-        aux_file: [b'n', b'o', b'n', b'e',
-            b' ', b' ', b' ', b' ', b' ', b' ', b' ', b' ', b' ', b' ',
-            b' ', b' ', b' ', b' ', b' ', b' ', b' ', b' ', b' ', 0],
+        aux_file: [
+            b'n', b'o', b'n', b'e', b' ', b' ', b' ', b' ', b' ', b' ', b' ', b' ', b' ', b' ',
+            b' ', b' ', b' ', b' ', b' ', b' ', b' ', b' ', b' ', 0,
+        ],
         qform_code: 0,
         sform_code: 4,
         srow_x: [-2., 0., 0., 90.],
@@ -148,8 +178,15 @@ fn avg152T1_LR_nii_gz() {
 
     const FILE_NAME: &str = "resources/avg152T1_LR_nifti.nii.gz";
     let header = NiftiHeader::from_file(FILE_NAME).unwrap();
-    
+
     assert_eq!(header, avg152t1_lr_hdr);
+
+    assert_eq!(header.intent().unwrap(), Intent::None);
+    assert_eq!(header.data_type().unwrap(), NiftiType::Uint8);
+    assert_eq!(header.xyzt_units().unwrap(), (Unit::Mm, Unit::Sec));
+    assert_eq!(header.slice_order().unwrap(), SliceOrder::Unknown);
+    assert_eq!(header.qform().unwrap(), XForm::Unknown);
+    assert_eq!(header.sform().unwrap(), XForm::Mni152);
 }
 
 #[test]
@@ -183,6 +220,13 @@ fn zstat1_nii_gz() {
 
     const FILE_NAME: &str = "resources/zstat1.nii.gz";
     let header = NiftiHeader::from_file(FILE_NAME).unwrap();
-    
+
     assert_eq!(header, zstat1_hdr);
+
+    assert_eq!(header.data_type().unwrap(), NiftiType::Float32);
+    assert_eq!(header.intent().unwrap(), Intent::Zscore);
+    assert_eq!(header.xyzt_units().unwrap(), (Unit::Mm, Unit::Sec));
+    assert_eq!(header.slice_order().unwrap(), SliceOrder::Unknown);
+    assert_eq!(header.qform().unwrap(), XForm::ScannerAnat);
+    assert_eq!(header.sform().unwrap(), XForm::Unknown);
 }

--- a/tests/object.rs
+++ b/tests/object.rs
@@ -5,7 +5,7 @@ extern crate nifti;
 #[macro_use]
 extern crate pretty_assertions;
 
-use nifti::{Endianness, InMemNiftiObject, NiftiHeader, NiftiObject, NiftiType, NiftiVolume};
+use nifti::{Endianness, InMemNiftiObject, NiftiHeader, NiftiObject, NiftiType, NiftiVolume, XForm};
 
 #[test]
 fn minimal_nii_gz() {
@@ -176,6 +176,9 @@ fn f32_nii_gz() {
     const FILE_NAME: &str = "resources/f32.nii.gz";
     let obj = InMemNiftiObject::from_file(FILE_NAME).unwrap();
     assert_eq!(obj.header(), &f32_hdr);
+
+    assert_eq!(obj.header().sform().unwrap(), XForm::AlignedAnat);
+
     let volume = obj.volume();
     assert_eq!(volume.data_type(), NiftiType::Float32);
     assert_eq!(volume.dim(), [11, 11, 11].as_ref());


### PR DESCRIPTION
- specify memory representation in `typedef::*` (u16 or u8 depending on attribute)
- make utility methods in `typedef::*` take `self` by value (cheaper than by ref)
- make volume construction methods yield an `InvalidCode` error (instead
of the less specific `InvalidFormat`)
- add `NiftiError::InvalidCode` variant
- add validating getters for these codes
- add methods for retrieving xyzt units with space-time separation

At first I considered modifying the attributes of `NiftiHeader` to contain these types immediately upon reading the header. With the repr directives, the header could still be packed without wasting memory and providing an extra layer of abstraction. However, I feel reluctant to make the entire reading process break just because of a single unknown code, which for the most part (`datatype` is an exception) are not critical. By keeping unvalidated codes, the library will give more flexibility to eventual file diagnostic tools.