### PR TITLE
Use Compression::fast

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -66,7 +66,7 @@ where
     let f = File::create(&path).expect("Can't create new nifti file");
     let mut writer = BufWriter::new(f);
     if is_gz_file(&path) {
-        let mut e = GzEncoder::new(writer, Compression::default());
+        let mut e = GzEncoder::new(writer, Compression::fast());
         write_header(&mut e, &header)?;
         write_data(&mut e, header, data)?;
         let _ = e.finish()?; // Must use result


### PR DESCRIPTION
We wondered for a long time why our writer was much slower than NiBabel. Turns out that `Compression::default()` is not

1. fast at all
2) what NiBabel [does](http://nipy.org/nibabel/reference/nibabel.openers.html). It's misleading. It looks like they use 9 (slowest) but their default is actually 1 (fastest).

With that change, we are as fast and even faster than NiBabel.