### PR TITLE
Update writer.rs to raise error from `File::create` on `write_nifti`

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -63,7 +63,7 @@ where
         ..reference
     };
 
-    let f = File::create(&path).expect("Can't create new nifti file");
+    let f = File::create(&path)?;
     let mut writer = BufWriter::new(f);
     if is_gz_file(&path) {
         let mut e = GzEncoder::new(writer, Compression::fast());


### PR DESCRIPTION
I might have overlooked this line back when reviewing #21. Failure to create the file should surely be recoverable.
