### PR TITLE
Use byteordered

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ branch = "master"
 repository = "Enet4/nifti-rs"
 
 [dependencies]
-byteorder = "1.2.1"
+byteordered = "0.3.1"
 derive_builder = "0.7.0"
 flate2 = "1.0.1"
 num = "0.2.0"

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,7 +1,7 @@
 //! This module defines the `NiftiHeader` struct, which is used
 //! to provide important information about NIFTI-1 volumes.
 
-use byteorder::{ByteOrder, NativeEndian, ReadBytesExt};
+use byteordered::{ByteOrdered, Endian, Endianness};
 use error::{NiftiError, Result};
 use flate2::bufread::GzDecoder;
 use num_traits::FromPrimitive;
@@ -9,7 +9,7 @@ use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::Path;
 use typedef::*;
-use util::{is_gz_file, Endianness, OppositeNativeEndian};
+use util::is_gz_file;
 
 /// Magic code for NIFTI-1 header files (extention ".hdr[.gz]").
 pub const MAGIC_CODE_NI1: &'static [u8; 4] = b"ni1\0";
@@ -150,7 +150,7 @@ pub struct NiftiHeader {
     pub magic: [u8; 4],
 
     /// Original data Endianness
-    #[builder(default = "Endianness::system()")]
+    #[builder(default = "Endianness::native()")]
     pub endianness: Endianness,
 }
 
@@ -205,7 +205,7 @@ impl Default for NiftiHeader {
 
             magic: *MAGIC_CODE_NI1,
 
-            endianness: Endianness::LE,
+            endianness: Endianness::Little,
         }
     }
 }
@@ -280,84 +280,88 @@ impl NiftiHeader {
     }
 }
 
-fn parse_header_1<S: Read>(mut input: S) -> Result<NiftiHeader> {
+fn parse_header_1<S>(input: S) -> Result<NiftiHeader> where S: Read {
     let mut h = NiftiHeader::default();
 
     // try the system's native endianness first
-    type B = NativeEndian;
+    let mut input = ByteOrdered::native(input);
 
-    h.sizeof_hdr = input.read_i32::<B>()?;
+    h.sizeof_hdr = input.read_i32()?;
     input.read_exact(&mut h.data_type)?;
     input.read_exact(&mut h.db_name)?;
-    h.extents = input.read_i32::<B>()?;
-    h.session_error = input.read_i16::<B>()?;
+    h.extents = input.read_i32()?;
+    h.session_error = input.read_i16()?;
     h.regular = input.read_u8()?;
     h.dim_info = input.read_u8()?;
-    h.dim[0] = input.read_u16::<B>()?;
+    h.dim[0] = input.read_u16()?;
 
     if h.dim[0] > 7 {
-        h.endianness = Endianness::system().opposite();
+        h.endianness = Endianness::native().to_opposite();
 
         // swap bytes read so far, continue with the opposite endianness
         h.sizeof_hdr = h.sizeof_hdr.swap_bytes();
         h.extents = h.extents.swap_bytes();
         h.session_error = h.session_error.swap_bytes();
         h.dim[0] = h.dim[0].swap_bytes();
-        parse_header_2::<OppositeNativeEndian, _>(h, input)
+        parse_header_2(h, input.into_opposite())
     } else {
         // all is well
-        h.endianness = Endianness::system();
-        parse_header_2::<B, _>(h, input)
+        h.endianness = Endianness::native();
+        parse_header_2(h, input)
     }
 }
 
 /// second part of header parsing
-fn parse_header_2<B: ByteOrder, S: Read>(mut h: NiftiHeader, mut input: S) -> Result<NiftiHeader> {
+fn parse_header_2<S, E>(mut h: NiftiHeader, mut input: ByteOrdered<S, E>) -> Result<NiftiHeader>
+where
+    S: Read,
+    E: Endian,
+{
     for v in &mut h.dim[1..] {
-        *v = input.read_u16::<B>()?;
+        *v = input.read_u16()?;
     }
-    h.intent_p1 = input.read_f32::<B>()?;
-    h.intent_p2 = input.read_f32::<B>()?;
-    h.intent_p3 = input.read_f32::<B>()?;
-    h.intent_code = input.read_i16::<B>()?;
-    h.datatype = input.read_i16::<B>()?;
-    h.bitpix = input.read_i16::<B>()?;
-    h.slice_start = input.read_i16::<B>()?;
+    h.intent_p1 = input.read_f32()?;
+    h.intent_p2 = input.read_f32()?;
+    h.intent_p3 = input.read_f32()?;
+    h.intent_code = input.read_i16()?;
+    h.datatype = input.read_i16()?;
+    h.bitpix = input.read_i16()?;
+    h.slice_start = input.read_i16()?;
     for v in &mut h.pixdim {
-        *v = input.read_f32::<B>()?;
+        *v = input.read_f32()?;
     }
-    h.vox_offset = input.read_f32::<B>()?;
-    h.scl_slope = input.read_f32::<B>()?;
-    h.scl_inter = input.read_f32::<B>()?;
-    h.slice_end = input.read_i16::<B>()?;
+    h.vox_offset = input.read_f32()?;
+    h.scl_slope = input.read_f32()?;
+    h.scl_inter = input.read_f32()?;
+    h.slice_end = input.read_i16()?;
     h.slice_code = input.read_u8()?;
     h.xyzt_units = input.read_u8()?;
-    h.cal_max = input.read_f32::<B>()?;
-    h.cal_min = input.read_f32::<B>()?;
-    h.slice_duration = input.read_f32::<B>()?;
-    h.toffset = input.read_f32::<B>()?;
-    h.glmax = input.read_i32::<B>()?;
-    h.glmin = input.read_i32::<B>()?;
+    h.cal_max = input.read_f32()?;
+    h.cal_min = input.read_f32()?;
+    h.slice_duration = input.read_f32()?;
+    h.toffset = input.read_f32()?;
+    h.glmax = input.read_i32()?;
+    h.glmin = input.read_i32()?;
 
     // descrip is 80-elem vec already
     input.read_exact(h.descrip.as_mut_slice())?;
     input.read_exact(&mut h.aux_file)?;
-    h.qform_code = input.read_i16::<B>()?;
-    h.sform_code = input.read_i16::<B>()?;
-    h.quatern_b = input.read_f32::<B>()?;
-    h.quatern_c = input.read_f32::<B>()?;
-    h.quatern_d = input.read_f32::<B>()?;
-    h.quatern_x = input.read_f32::<B>()?;
-    h.quatern_y = input.read_f32::<B>()?;
-    h.quatern_z = input.read_f32::<B>()?;
+    h.qform_code = input.read_i16()?;
+    h.sform_code = input.read_i16()?;
+    h.quatern_b = input.read_f32()?;
+    h.quatern_c = input.read_f32()?;
+    h.quatern_d = input.read_f32()?;
+    h.quatern_x = input.read_f32()?;
+    h.quatern_y = input.read_f32()?;
+    h.quatern_z = input.read_f32()?;
     for v in &mut h.srow_x {
-        *v = input.read_f32::<B>()?;
+        *v = input.read_f32()?;
     }
     for v in &mut h.srow_y {
-        *v = input.read_f32::<B>()?;
+        *v = input.read_f32()?;
     }
     for v in &mut h.srow_z {
-        *v = input.read_f32::<B>()?;
+        *v = input.read_f32()?;
     }
     input.read_exact(&mut h.intent_name)?;
     input.read_exact(&mut h.magic)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 #[macro_use] extern crate derive_builder;
 #[cfg(feature = "ndarray_volumes")] extern crate ndarray;
 
-extern crate byteorder;
+extern crate byteordered;
 extern crate flate2;
 extern crate num_traits;
 extern crate safe_transmute;
@@ -75,4 +75,4 @@ pub use volume::{NiftiVolume, InMemNiftiVolume, Sliceable};
 pub use volume::element::DataElement;
 #[cfg(feature = "ndarray_volumes")] pub use volume::ndarray::IntoNdArray;
 pub use typedef::{NiftiType, Unit, Intent, XForm, SliceOrder};
-pub use util::Endianness;
+pub use byteordered::Endianness;

--- a/src/typedef.rs
+++ b/src/typedef.rs
@@ -8,7 +8,7 @@ use volume::element::{DataElement, LinearTransform};
 use error::{NiftiError, Result};
 use std::io::Read;
 use std::ops::{Add, Mul};
-use util::Endianness;
+use byteordered::{Endian, Endianness};
 use num_traits::AsPrimitive;
 
 /// Data type for representing a NIFTI value type in a volume.

--- a/tests/header.rs
+++ b/tests/header.rs
@@ -17,7 +17,7 @@ fn minimal_hdr() {
         scl_slope: 0.,
         scl_inter: 0.,
         magic: *b"ni1\0",
-        endianness: Endianness::BE,
+        endianness: Endianness::Big,
         ..Default::default()
     };
 
@@ -46,7 +46,7 @@ fn minimal_hdr_gz() {
         scl_slope: 0.,
         scl_inter: 0.,
         magic: *b"ni1\0",
-        endianness: Endianness::BE,
+        endianness: Endianness::Big,
         ..Default::default()
     };
 
@@ -75,7 +75,7 @@ fn minimal_nii() {
         scl_slope: 0.,
         scl_inter: 0.,
         magic: *b"n+1\0",
-        endianness: Endianness::BE,
+        endianness: Endianness::Big,
         ..Default::default()
     };
 
@@ -84,7 +84,7 @@ fn minimal_nii() {
     let header = NiftiHeader::from_stream(file).unwrap();
 
     assert_eq!(header, minimal_hdr);
-    assert_eq!(header.endianness, Endianness::BE);
+    assert_eq!(header.endianness, Endianness::Big);
 
     assert_eq!(header.intent().unwrap(), Intent::None);
     assert_eq!(header.data_type().unwrap(), NiftiType::Uint8);
@@ -124,7 +124,7 @@ fn avg152T1_LR_hdr_gz() {
         srow_y: [0., 2., 0., -126.],
         srow_z: [0., 0., 2., -72.],
         magic: *b"ni1\0",
-        endianness: Endianness::BE,
+        endianness: Endianness::Big,
         ..Default::default()
     };
 
@@ -132,7 +132,7 @@ fn avg152T1_LR_hdr_gz() {
     let header = NiftiHeader::from_file(FILE_NAME).unwrap();
 
     assert_eq!(header, avg152t1_lr_hdr);
-    assert_eq!(header.endianness, Endianness::BE);
+    assert_eq!(header.endianness, Endianness::Big);
 
     assert_eq!(header.intent().unwrap(), Intent::None);
     assert_eq!(header.data_type().unwrap(), NiftiType::Uint8);
@@ -172,7 +172,7 @@ fn avg152T1_LR_nii_gz() {
         srow_y: [0., 2., 0., -126.],
         srow_z: [0., 0., 2., -72.],
         magic: *b"n+1\0",
-        endianness: Endianness::BE,
+        endianness: Endianness::Big,
         ..Default::default()
     };
 
@@ -214,7 +214,7 @@ fn zstat1_nii_gz() {
         quatern_b: 0.,
         quatern_c: 1.,
         magic: *b"n+1\0",
-        endianness: Endianness::BE,
+        endianness: Endianness::Big,
         ..Default::default()
     };
 

--- a/tests/object.rs
+++ b/tests/object.rs
@@ -19,7 +19,7 @@ fn minimal_nii_gz() {
         scl_slope: 0.,
         scl_inter: 0.,
         magic: *b"n+1\0",
-        endianness: Endianness::BE,
+        endianness: Endianness::Big,
         ..Default::default()
     };
 
@@ -43,7 +43,7 @@ fn minimal_nii() {
         scl_slope: 0.,
         scl_inter: 0.,
         magic: *b"n+1\0",
-        endianness: Endianness::BE,
+        endianness: Endianness::Big,
         ..Default::default()
     };
 
@@ -67,7 +67,7 @@ fn minimal_by_hdr() {
         scl_slope: 0.,
         scl_inter: 0.,
         magic: *b"ni1\0",
-        endianness: Endianness::BE,
+        endianness: Endianness::Big,
         ..Default::default()
     };
 
@@ -91,7 +91,7 @@ fn minimal_by_hdr_and_img_gz() {
         scl_slope: 0.,
         scl_inter: 0.,
         magic: *b"ni1\0",
-        endianness: Endianness::BE,
+        endianness: Endianness::Big,
         ..Default::default()
     };
 
@@ -116,7 +116,7 @@ fn minimal_by_hdr_gz() {
         scl_slope: 0.,
         scl_inter: 0.,
         magic: *b"ni1\0",
-        endianness: Endianness::BE,
+        endianness: Endianness::Big,
         ..Default::default()
     };
 
@@ -140,7 +140,7 @@ fn minimal_by_pair() {
         scl_slope: 0.,
         scl_inter: 0.,
         magic: *b"ni1\0",
-        endianness: Endianness::BE,
+        endianness: Endianness::Big,
         ..Default::default()
     };
 
@@ -169,7 +169,7 @@ fn f32_nii_gz() {
         srow_z: [0., 0., 1., 0.],
         sform_code: 2,
         magic: *b"n+1\0",
-        endianness: Endianness::LE,
+        endianness: Endianness::Little,
         ..Default::default()
     };
 

--- a/tests/volume.rs
+++ b/tests/volume.rs
@@ -27,7 +27,7 @@ fn minimal_img_gz() {
         scl_slope: 0.,
         scl_inter: 0.,
         magic: *b"ni1\0",
-        endianness: Endianness::BE,
+        endianness: Endianness::Big,
         ..Default::default()
     };
 
@@ -74,7 +74,7 @@ mod ndarray_volumes {
             scl_slope: 0.,
             scl_inter: 0.,
             magic: *b"ni1\0",
-            endianness: Endianness::BE,
+            endianness: Endianness::Big,
             ..Default::default()
         };
 
@@ -112,7 +112,7 @@ mod ndarray_volumes {
             scl_slope: 0.,
             scl_inter: 0.,
             magic: *b"ni1\0",
-            endianness: Endianness::BE,
+            endianness: Endianness::Big,
             ..Default::default()
         };
 


### PR DESCRIPTION
This PR changes the data encoding and decoding routines to use [`byteordered`](https://docs.rs/byteordered/0.3.1/byteordered/). It is an alternative API with a byte order wrapper, so that reads and writes do not have to explicitly state the expected order in each call, and it also works for an endianness only known at run-time.

This makes the code base a bit cleaner, especially in util.rs since we no longer have to define `Endianness` here, and should also make #34 significantly easier to address. The only breaking change is that now `Endianness` is provided by `byteordered`, which has a few changes in associated functions and variant names (conventional naming: `Little` instead of `LE` and `Big` instead of `BE`).
