### PR TITLE
Fix Big Endian writing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ branch = "master"
 repository = "Enet4/nifti-rs"
 
 [dependencies]
-byteordered = "0.3.1"
+byteordered = "0.4.0"
 derive_builder = "0.7.0"
 flate2 = "1.0.1"
 num = "0.2.0"

--- a/src/header.rs
+++ b/src/header.rs
@@ -324,7 +324,10 @@ impl NiftiHeader {
     }
 }
 
-fn parse_header_1<S>(input: S) -> Result<NiftiHeader> where S: Read {
+fn parse_header_1<S>(input: S) -> Result<NiftiHeader>
+where
+    S: Read,
+{
     let mut h = NiftiHeader::default();
 
     // try the system's native endianness first

--- a/src/util.rs
+++ b/src/util.rs
@@ -44,6 +44,7 @@ where
 /// Adapt a sequence of bytes for reading contiguous values of type `T`,
 /// by swapping bytes if the given endianness is not native. If no
 /// swapping is needed, the same byte slice is returned.
+#[cfg_attr(not(feature = "ndarray_volumes"), allow(dead_code))]
 pub fn adapt_bytes<T, E>(bytes: &[u8], e: E) -> Cow<[u8]>
 where
     E: Endian,

--- a/src/util.rs
+++ b/src/util.rs
@@ -17,6 +17,16 @@ where
     T: PodTransmutable,
     E: Endian,
 {
+    adapt_bytes::<T, _>(&mut a, e);
+    guarded_transmute_pod_vec_permissive(a)
+}
+
+/// Adapt a sequence of bytes for reading contiguous values of type `T`,
+/// by swapping bytes if the given endianness is not native.
+pub fn adapt_bytes<T, E>(a: &mut [u8], e: E)
+where
+    E: Endian,
+{
     let nb_bytes = mem::size_of::<T>();
     if !e.is_native() && nb_bytes > 1 {
         // Swap endianness by block of nb_bytes
@@ -28,8 +38,6 @@ where
             }
         }
     }
-
-    guarded_transmute_pod_vec_permissive(a)
 }
 
 pub fn nb_bytes_for_data(header: &NiftiHeader) -> usize {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,5 @@
 //! Private utility module
+use std::borrow::Cow;
 use std::io::{Read, Seek};
 use std::mem;
 use std::path::{Path, PathBuf};
@@ -17,13 +18,13 @@ where
     T: PodTransmutable,
     E: Endian,
 {
-    adapt_bytes::<T, _>(&mut a, e);
+    adapt_bytes_inline::<T, _>(&mut a, e);
     guarded_transmute_pod_vec_permissive(a)
 }
 
 /// Adapt a sequence of bytes for reading contiguous values of type `T`,
 /// by swapping bytes if the given endianness is not native.
-pub fn adapt_bytes<T, E>(a: &mut [u8], e: E)
+pub fn adapt_bytes_inline<T, E>(a: &mut [u8], e: E)
 where
     E: Endian,
 {
@@ -37,6 +38,24 @@ where
                 mem::swap(l, r);
             }
         }
+    }
+}
+
+/// Adapt a sequence of bytes for reading contiguous values of type `T`,
+/// by swapping bytes if the given endianness is not native. If no
+/// swapping is needed, the same byte slice is returned.
+pub fn adapt_bytes<T, E>(bytes: &[u8], e: E) -> Cow<[u8]>
+where
+    E: Endian,
+{
+    let nb_bytes = mem::size_of::<T>();
+    if !e.is_native() && nb_bytes > 1 {
+        // Swap endianness by block of nb_bytes
+        let mut a = bytes.to_vec();
+        adapt_bytes_inline::<T, E>(&mut a, e);
+        a.into()
+    } else {
+        bytes.into()
     }
 }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -11,11 +11,10 @@ use flate2::Compression;
 use ndarray::{ArrayBase, ArrayView, Axis, Data, Dimension, RemoveAxis, ScalarOperand};
 use num_traits::FromPrimitive;
 use safe_transmute::{guarded_transmute_to_bytes_pod_many, PodTransmutable};
-use util::adapt_bytes;
 
 use {
     header::{MAGIC_CODE_NI1, MAGIC_CODE_NIP1},
-    util::{is_gz_file, is_hdr_file},
+    util::{is_gz_file, is_hdr_file, adapt_bytes},
     volume::element::DataElement,
     NiftiHeader, NiftiType, Result,
 };
@@ -369,9 +368,9 @@ where
     let len = data.len();
     let arr_data = data.into_shape(len).unwrap();
     let slice = arr_data.as_slice().unwrap();
-    let mut bytes = guarded_transmute_to_bytes_pod_many(slice).to_vec();
+    let bytes = guarded_transmute_to_bytes_pod_many(slice);
     let (writer, endianness) = writer.into_parts();
-    adapt_bytes::<B, _>(&mut bytes, endianness);
+    let bytes = adapt_bytes::<B, _>(&bytes, endianness);
     writer.write_all(&*bytes)?;
     Ok(())
 }


### PR DESCRIPTION
Also introducing the longest turbo fish I ever made. :neutral_face: This was a consequence of distinguishing the array's element type `A` from the array's "atomic element" type `B`. In RGB, `A = [u8; 3]` and `B = u8`, whereas so far `A = B` for other cases. With this extra type parameter, we can use the same functions for both.

Resolves #34.