### PR TITLE
Affine management

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,18 @@ rust:
 matrix:
   include:
     - rust: stable
-      env: CARGO_FEATURES="--features ndarray_volumes""
+      env: CARGO_FEATURES="--features nalgebra_affine,ndarray_volumes""
     - rust: beta
-      env: CARGO_FEATURES="--features ndarray_volumes""
+      env: CARGO_FEATURES="--features nalgebra_affine,ndarray_volumes""
     - rust: nightly
-      env: CARGO_FEATURES="--features ndarray_volumes""
+      env: CARGO_FEATURES="--features nalgebra_affine,ndarray_volumes""
     - rust: stable
-      env: CARGO_FEATURES="--features ndarray_volumes"
+      env: CARGO_FEATURES="--features nalgebra_affine,ndarray_volumes"
       os: windows
     - rust: stable
-      env: CARGO_FEATURES="--features ndarray_volumes"
+      env: CARGO_FEATURES="--features nalgebra_affine,ndarray_volumes"
       os: osx
-    - env: CROSS_TARGET=mips64-unknown-linux-gnuabi64 CARGO_FEATURES="--features ndarray_volumes"
+    - env: CROSS_TARGET=mips64-unknown-linux-gnuabi64 CARGO_FEATURES="--features nalgebra_affine,ndarray_volumes"
       rust: stable
       services: docker
       sudo: required

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,10 @@ num-traits = "0.2.0"
 quick-error = "1.2.0"
 safe-transmute = "0.9.0"
 
+[dependencies.nalgebra]
+optional = true
+version = "0.16"
+
 [dependencies.ndarray]
 optional = true
 version = ">=0.10.12,<0.13.0"
@@ -40,6 +44,7 @@ name = "niftidump"
 path = "examples/niftidump/main.rs"
 
 [features]
+nalgebra_affine = ["nalgebra"]
 ndarray_volumes = ["ndarray"]
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,10 @@ num-traits = "0.2.0"
 quick-error = "1.2.0"
 safe-transmute = "0.9.0"
 
+[dependencies.alga]
+optional = true
+version = "0.7"
+
 [dependencies.nalgebra]
 optional = true
 version = "0.16"
@@ -44,7 +48,7 @@ name = "niftidump"
 path = "examples/niftidump/main.rs"
 
 [features]
-nalgebra_affine = ["nalgebra"]
+nalgebra_affine = ["alga", "nalgebra"]
 ndarray_volumes = ["ndarray"]
 
 [package.metadata.docs.rs]

--- a/src/affine.rs
+++ b/src/affine.rs
@@ -1,12 +1,16 @@
+//! This module defines some affine-related utilities.
+
 use nalgebra::{Matrix3, Matrix4, Quaternion, RowVector4, Scalar, SymmetricEigen, Vector3, U1, U3};
 
+/// 3x3 affine transformation matrix.
 pub type Affine3 = Matrix3<f32>;
+/// 4x4 affine transformation matrix.
 pub type Affine4 = Matrix4<f32>;
 
 const QUARTERNION_THRESHOLD: f32 = -::std::f32::EPSILON * 3.0;
 
 /// Separate a 4x4 affine into its 3x3 affine and translation components.
-pub fn get_affine_and_translation<T: Scalar>(affine: &Matrix4<T>) -> (Matrix3<T>, Vector3<T>) {
+pub fn affine_and_translation<T: Scalar>(affine: &Matrix4<T>) -> (Matrix3<T>, Vector3<T>) {
     let translation = Vector3::<T>::new(affine[12], affine[13], affine[14]);
     let affine = affine.fixed_slice::<U3, U3>(0, 0).into_owned();
     (affine, translation)

--- a/src/affine.rs
+++ b/src/affine.rs
@@ -1,0 +1,141 @@
+use nalgebra::{Matrix3, Matrix4, Quaternion, RowVector4, Scalar, SymmetricEigen, Vector3, U1, U3};
+
+pub type Affine3 = Matrix3<f32>;
+pub type Affine4 = Matrix4<f32>;
+
+const QUARTERNION_THRESHOLD: f32 = -::std::f32::EPSILON * 3.0;
+
+/// Separate a 4x4 affine into its 3x3 affine and translation components.
+pub fn get_affine_and_translation<T: Scalar>(affine: &Matrix4<T>) -> (Matrix3<T>, Vector3<T>) {
+    let translation = Vector3::<T>::new(affine[12], affine[13], affine[14]);
+    let affine = affine.fixed_slice::<U3, U3>(0, 0).into_owned();
+    (affine, translation)
+}
+
+/// Get affine implied by given shape and zooms.
+///
+/// We get the translations from the center of the image (implied by `shape`).
+pub(crate) fn shape_zoom_affine(shape: &[u16], spacing: &[f32]) -> Affine4 {
+    // Get translations from center of image
+    let origin = Vector3::new(
+        (shape[0] as f32 - 1.0) / 2.0,
+        (shape[1] as f32 - 1.0) / 2.0,
+        (shape[2] as f32 - 1.0) / 2.0,
+    );
+    let spacing = [-spacing[0] as f32, spacing[1] as f32, spacing[2] as f32];
+    Affine4::new(
+        spacing[0], 0.0, 0.0, -origin[0] * spacing[0],
+        0.0, spacing[1], 0.0, -origin[1] * spacing[1],
+        0.0, 0.0, spacing[2], -origin[2] * spacing[2],
+        0.0, 0.0, 0.0, 1.0,
+    )
+}
+
+/// Compute unit quaternion from last 3 values.
+///
+/// If w, x, y, z are the values in the full quaternion, assumes w is positive.
+/// Panic if w*w is estimated to be negative.
+/// w = 0.0 corresponds to a 180 degree rotation.
+/// The unit quaternion specifies that `wxyz.dot(wxyz) == 1.0`.
+///
+/// If w is positive (assumed here), w is given by:
+///     w = (1.0 - (x*x + y*y + z*z)).sqrt()
+/// `1.0 - (x*x + y*y + z*z)` can be near zero, which will lead to numerical instability in sqrt.
+/// Here we use f64 to reduce numerical instability.
+pub(crate) fn fill_positive(xyz: Vector3<f32>) -> Quaternion<f32> {
+    let xyz: Vector3<f32> = nalgebra::convert(xyz);
+    let w2 = 1.0 - xyz.dot(&xyz);
+    let w = if w2 < 0.0 {
+        if w2 < QUARTERNION_THRESHOLD {
+            panic!("1.0 - (x*x + y*y + z*z) should be positive, but is {}", w2);
+        }
+        0.0
+    } else {
+        w2.sqrt()
+    };
+    Quaternion::new(w as f32, xyz.x as f32, xyz.y as f32, xyz.z as f32)
+}
+
+/// Calculate quaternion corresponding to given rotation matrix.
+///
+/// Method claimed to be robust to numerical errors in `affine`. Constructs quaternion by
+/// calculating maximum eigenvector for matrix `k` (constructed from input `affine`). Although this
+/// is not tested, a maximum eigenvalue of 1 corresponds to a valid rotation.
+///
+/// A quaternion `q * -1.0` corresponds to the same rotation as `q`; thus the sign of the
+/// reconstructed quaternion is arbitrary, and we return quaternions with positive `w` `(q[0])`.
+///
+/// Bar-Itzhack, Itzhack Y. "New method for extracting the quaternion from a rotation
+/// matrix", AIAA Journal of Guidance, Control and Dynamics 23(6):1085-1087, 2000
+pub(crate) fn affine_to_quaternion(affine: &Affine3) -> RowVector4<f32> {
+    // qyx refers to the contribution of the y input vector component to the x output vector
+    // component. qyx is therefore the same as M[0, 1]. The notation is from the Wikipedia article.
+    let qxx = affine[0];
+    let qyx = affine[3];
+    let qzx = affine[6];
+    let qxy = affine[1];
+    let qyy = affine[4];
+    let qzy = affine[7];
+    let qxz = affine[2];
+    let qyz = affine[5];
+    let qzz = affine[8];
+
+    // Fill only lower half of symmetric matrix
+    let k = Affine4::new(
+        qxx - qyy - qzz, 0.0,             0.0,             0.0,
+        qyx + qxy,       qyy - qxx - qzz, 0.0,             0.0,
+        qzx + qxz,       qzy + qyz,       qzz - qxx - qyy, 0.0,
+        qyz - qzy,       qzx - qxz,       qxy - qyx,       qxx + qyy + qzz,
+    );
+
+    // Use Hermitian eigenvectors, values for speed
+    let SymmetricEigen { eigenvalues: values, eigenvectors: vectors } = k.symmetric_eigen();
+
+    // Select largest eigenvector, reorder to w,x,y,z quaternion
+    let (max_idx, _) = values
+        .as_slice()
+        .iter()
+        .enumerate()
+        .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+        .unwrap();
+    let max_vector = vectors.fixed_columns::<U1>(max_idx);
+    let quaternion = RowVector4::new(max_vector[3], max_vector[0], max_vector[1], max_vector[2]);
+
+    // Prefer quaternion with positive `w`.
+    if quaternion[0] < 0.0 {
+        quaternion * -1.0
+    } else {
+        quaternion
+    }
+}
+
+/// Calculate rotation matrix corresponding to quaternion.
+///
+/// Rotation matrix applies to column vectors, and is applied to the left of coordinate vectors.
+/// The algorithm here allows non-unit quaternions.
+///
+/// Algorithm from https://en.wikipedia.org/wiki/Rotation_matrix#Quaternion
+pub(crate) fn quaternion_to_affine(q: Quaternion<f32>) -> Affine3 {
+    let nq = q.w * q.w + q.i * q.i + q.j * q.j + q.k * q.k;
+    if nq < ::std::f32::EPSILON {
+        return Affine3::identity();
+    }
+    let s = 2.0 / nq;
+    let x = q.i * s;
+    let y = q.j * s;
+    let z = q.k * s;
+    let wx = q.w * x;
+    let wy = q.w * y;
+    let wz = q.w * z;
+    let xx = q.i * x;
+    let xy = q.i * y;
+    let xz = q.i * z;
+    let yy = q.j * y;
+    let yz = q.j * z;
+    let zz = q.k * z;
+    Affine3::new(
+        1.0 - (yy + zz), xy - wz, xz + wy,
+        xy + wz, 1.0 - (xx + zz), yz - wx,
+        xz - wy, yz + wx, 1.0 - (xx + yy),
+    )
+}

--- a/src/affine.rs
+++ b/src/affine.rs
@@ -80,7 +80,7 @@ pub(crate) fn affine_to_quaternion(affine: &Affine3) -> RowVector4<f32> {
     let qyz = affine[5];
     let qzz = affine[8];
 
-    // Fill only lower half of symmetric matrix
+    // Fill only lower half of symmetric matrix.
     let k = Affine4::new(
         qxx - qyy - qzz, 0.0,             0.0,             0.0,
         qyx + qxy,       qyy - qxx - qzz, 0.0,             0.0,
@@ -88,10 +88,13 @@ pub(crate) fn affine_to_quaternion(affine: &Affine3) -> RowVector4<f32> {
         qyz - qzy,       qzx - qxz,       qxy - qyx,       qxx + qyy + qzz,
     );
 
-    // Use Hermitian eigenvectors, values for speed
-    let SymmetricEigen { eigenvalues: values, eigenvectors: vectors } = k.symmetric_eigen();
+    // Use Hermitian eigenvectors, values for speed.
+    let SymmetricEigen {
+        eigenvalues: values,
+        eigenvectors: vectors,
+    } = k.symmetric_eigen();
 
-    // Select largest eigenvector, reorder to w,x,y,z quaternion
+    // Select largest eigenvector, reorder to w,x,y,z quaternion.
     let (max_idx, _) = values
         .as_slice()
         .iter()
@@ -175,11 +178,16 @@ mod tests {
 
     #[test]
     fn test_affine_to_quaternion() {
-        let affine = Matrix3::<f32>::identity();
-        assert_eq!(affine_to_quaternion(&affine), RowVector4::new(1.0, 0.0, 0.0, 0.0));
+        assert_eq!(
+            affine_to_quaternion(&Affine3::identity()),
+            RowVector4::new(1.0, 0.0, 0.0, 0.0)
+        );
 
         let affine = Matrix3::from_diagonal(&Vector3::new(1.0, -1.0, -1.0));
-        assert_eq!(affine_to_quaternion(&affine), RowVector4::new(0.0, 1.0, 0.0, 0.0));
+        assert_eq!(
+            affine_to_quaternion(&affine),
+            RowVector4::new(0.0, 1.0, 0.0, 0.0)
+        );
 
         let affine = Matrix3::new(1.1, 0.1, 0.1, 0.2, 1.1, 0.5, 0.0, 0.0, 1.0);
         assert_eq!(
@@ -196,6 +204,9 @@ mod tests {
 
         // 180 degree rotation around axis 0
         let affine = quaternion_to_affine(Quaternion::new(0.0, 1.0, 0.0, 0.0));
-        assert_eq!(affine, Matrix3::new(1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, -1.0));
+        assert_eq!(
+            affine,
+            Matrix3::from_diagonal(&Vector3::new(1.0, -1.0, -1.0))
+        );
     }
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -407,14 +407,14 @@ impl NiftiHeader {
     /// nifti readers because the `qform_code` will be set to 'Unknown'.
     pub fn set_affine(&mut self, affine: &Affine4) {
         // Set affine into sform with default code.
-        self.set_sform(affine, 2);
+        self.set_sform(affine, XForm::AlignedAnat);
 
         // Make qform 'unknown'.
-        self.set_qform(affine, 0);
+        self.set_qform(affine, XForm::Unknown);
     }
 
     /// Set affine transformation in 'sform' fields.
-    fn set_sform(&mut self, affine: &Affine4, code: usize) {
+    fn set_sform(&mut self, affine: &Affine4, code: XForm) {
         self.sform_code = code as i16;
         self.srow_x[0] = affine[0];
         self.srow_x[1] = affine[4];
@@ -436,7 +436,7 @@ impl NiftiHeader {
     /// components to the `affine` transform, the written qform gives the closest approximation
     /// where the rotation matrix is orthogonal. This is to allow quaternion representation. The
     /// orthogonal representation enforces orthogonal axes.
-    fn set_qform(&mut self, affine4: &Affine4, code: usize) {
+    fn set_qform(&mut self, affine4: &Affine4, code: XForm) {
         let (affine, translation) = get_affine_and_translation(&affine4);
         let aff2 = affine.component_mul(&affine);
         let spacing = (

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,11 +1,13 @@
 //! This module defines the `NiftiHeader` struct, which is used
 //! to provide important information about NIFTI-1 volumes.
 
-#[cfg(feature = "nalgebra_affine")] use affine::*;
+#[cfg(feature = "nalgebra_affine")]
+use affine::*;
 use byteordered::{ByteOrdered, Endian, Endianness};
 use error::{NiftiError, Result};
 use flate2::bufread::GzDecoder;
-#[cfg(feature = "nalgebra_affine")] use nalgebra::{Quaternion, Vector3};
+#[cfg(feature = "nalgebra_affine")]
+use nalgebra::{Quaternion, Vector3};
 use num_traits::FromPrimitive;
 use std::fs::File;
 use std::io::{BufReader, Read};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@
 #[macro_use] extern crate quick_error;
 #[macro_use] extern crate num_derive;
 #[macro_use] extern crate derive_builder;
+#[cfg(feature = "nalgebra_affine")] extern crate nalgebra;
 #[cfg(feature = "ndarray_volumes")] extern crate ndarray;
 
 extern crate byteordered;
@@ -58,6 +59,7 @@ extern crate flate2;
 extern crate num_traits;
 extern crate safe_transmute;
 
+#[cfg(feature = "nalgebra_affine")] mod affine;
 pub mod extension;
 pub mod header;
 pub mod object;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@
 #[macro_use] extern crate quick_error;
 #[macro_use] extern crate num_derive;
 #[macro_use] extern crate derive_builder;
+#[cfg(feature = "nalgebra_affine")] extern crate alga;
 #[cfg(feature = "nalgebra_affine")] extern crate nalgebra;
 #[cfg(feature = "ndarray_volumes")] extern crate ndarray;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ extern crate flate2;
 extern crate num_traits;
 extern crate safe_transmute;
 
-#[cfg(feature = "nalgebra_affine")] mod affine;
+#[cfg(feature = "nalgebra_affine")] pub mod affine;
 pub mod extension;
 pub mod header;
 pub mod object;

--- a/tests/affine.rs
+++ b/tests/affine.rs
@@ -1,12 +1,14 @@
-#[cfg(feature = "nalgebra_affine")] extern crate nalgebra;
-#[cfg(feature = "nalgebra_affine")] extern crate nifti;
+#[cfg(feature = "nalgebra_affine")]
+extern crate nalgebra;
+#[cfg(feature = "nalgebra_affine")]
+extern crate nifti;
 
 #[cfg(feature = "nalgebra_affine")]
 mod nalgebra_affine {
     use nalgebra::Vector4;
     use nifti::{affine::Affine4, NiftiHeader};
 
-        #[test]
+    #[test]
     fn affine() {
         let mut header = NiftiHeader::default();
         let affine = Affine4::from_diagonal(&Vector4::new(2.0, 2.0, 2.0, 1.0));
@@ -25,12 +27,13 @@ mod nalgebra_affine {
         header.srow_y = [0.1, 2.4995277, 0.0485984, -97.420204];
         header.srow_z = [0.4, -0.0485, 2.4991884, -89.12282];
 
-        assert_eq!(header.affine(), Affine4::new(
+        let real_affine = Affine4::new(
             2.4, -0.0008,    -0.0411765, -114.766396,
             0.1,  2.4995277,  0.0485984,  -97.420204,
             0.4, -0.0485,     2.4991884,  -89.12282,
-            0.0, 0.0, 0.0, 1.0
-        ));
+            0.0,  0.0,        0.0,          1.0
+        );
+        assert_eq!(header.affine(), real_affine);
     }
 
     #[test]
@@ -46,12 +49,13 @@ mod nalgebra_affine {
         header.quatern_y = 73.172;
         header.quatern_z = 43.4291;
 
-        assert_eq!(header.affine(), Affine4::new(
+        let real_affine = Affine4::new(
             -0.9375, 0.0,    0.0, 59.557503,
             0.0,     0.9375, 0.0, 73.172,
             0.0,     0.0,    3.0, 43.4291,
             0.0,     0.0,    0.0, 1.0
-        ));
+        );
+        assert_eq!(header.affine(), real_affine);
     }
 
     #[test]
@@ -72,12 +76,13 @@ mod nalgebra_affine {
         header.quatern_y = 73.0;
         header.quatern_z = 43.0;
 
-        assert_eq!(header.affine(), Affine4::new(
+        let real_affine = Affine4::new(
             2.4, 0.0, 0.0, -114.766396,
             0.1, 2.4, 0.0, -97.420204,
             0.4, 0.4, 2.4, -89.12282,
             0.0, 0.0, 0.0, 1.0
-        ));
+        );
+        assert_eq!(header.affine(), real_affine);
     }
 
     #[test]
@@ -99,11 +104,12 @@ mod nalgebra_affine {
         header.quatern_y = 73.0;
         header.quatern_z = 43.0;
 
-        assert_eq!(header.affine(), Affine4::new(
+        let real_affine = Affine4::new(
             -0.9, 0.0, 0.0,   44.55,
             0.0,  0.9, 0.0,  -44.55,
             0.0,  0.0, 3.0, -148.5,
             0.0, 0.0, 0.0, 1.0
-        ));
+        );
+        assert_eq!(header.affine(), real_affine);
     }
 }

--- a/tests/affine.rs
+++ b/tests/affine.rs
@@ -1,0 +1,109 @@
+#[cfg(feature = "nalgebra_affine")] extern crate nalgebra;
+#[cfg(feature = "nalgebra_affine")] extern crate nifti;
+
+#[cfg(feature = "nalgebra_affine")]
+mod nalgebra_affine {
+    use nalgebra::Vector4;
+    use nifti::{affine::Affine4, NiftiHeader};
+
+        #[test]
+    fn affine() {
+        let mut header = NiftiHeader::default();
+        let affine = Affine4::from_diagonal(&Vector4::new(2.0, 2.0, 2.0, 1.0));
+        header.set_affine(&affine);
+        assert_eq!(affine, header.affine());
+        assert_eq!(header.sform_code, 2);
+        assert_eq!(header.qform_code, 0);
+    }
+
+    #[test]
+    fn sform() {
+        let mut header = NiftiHeader::default();
+        header.sform_code = 1;
+        header.qform_code = 0;
+        header.srow_x = [2.4, -0.0008, -0.0411765, -114.766396];
+        header.srow_y = [0.1, 2.4995277, 0.0485984, -97.420204];
+        header.srow_z = [0.4, -0.0485, 2.4991884, -89.12282];
+
+        assert_eq!(header.affine(), Affine4::new(
+            2.4, -0.0008,    -0.0411765, -114.766396,
+            0.1,  2.4995277,  0.0485984,  -97.420204,
+            0.4, -0.0485,     2.4991884,  -89.12282,
+            0.0, 0.0, 0.0, 1.0
+        ));
+    }
+
+    #[test]
+    fn qform() {
+        let mut header = NiftiHeader::default();
+        header.sform_code = 0;
+        header.qform_code = 1;
+        header.pixdim = [-1.0, 0.9375, 0.9375, 3.0, 0.0, 0.0, 0.0, 0.0];
+        header.quatern_b = 0.0;
+        header.quatern_c = 1.0;
+        header.quatern_d = 0.0;
+        header.quatern_x = 59.557503;
+        header.quatern_y = 73.172;
+        header.quatern_z = 43.4291;
+
+        assert_eq!(header.affine(), Affine4::new(
+            -0.9375, 0.0,    0.0, 59.557503,
+            0.0,     0.9375, 0.0, 73.172,
+            0.0,     0.0,    3.0, 43.4291,
+            0.0,     0.0,    0.0, 1.0
+        ));
+    }
+
+    #[test]
+    fn both_valid() {
+        let mut header = NiftiHeader::default();
+        header.sform_code = 1;
+        header.srow_x = [2.4, 0.0, 0.0, -114.766396];
+        header.srow_y = [0.1, 2.4, 0.0, -97.420204];
+        header.srow_z = [0.4, 0.4, 2.4, -89.12282];
+
+        // All this should be ignored
+        header.qform_code = 1;
+        header.pixdim = [-1.0, 0.9375, 0.9375, 3.0, 0.0, 0.0, 0.0, 0.0];
+        header.quatern_b = 0.0;
+        header.quatern_c = 1.0;
+        header.quatern_d = 0.0;
+        header.quatern_x = 59.0;
+        header.quatern_y = 73.0;
+        header.quatern_z = 43.0;
+
+        assert_eq!(header.affine(), Affine4::new(
+            2.4, 0.0, 0.0, -114.766396,
+            0.1, 2.4, 0.0, -97.420204,
+            0.4, 0.4, 2.4, -89.12282,
+            0.0, 0.0, 0.0, 1.0
+        ));
+    }
+
+    #[test]
+    fn none_valid() {
+        let mut header = NiftiHeader::default();
+        header.dim = [3, 100, 100, 100, 0, 0, 0, 0];
+        header.pixdim = [-1.0, 0.9, 0.9, 3.0, 0.0, 0.0, 0.0, 0.0];
+
+        // All this should be ignored, because only `shape_zoom_affine` will be called.
+        header.sform_code = 0;
+        header.srow_x = [1.0, 0.0, 0.0, 1.0];
+        header.srow_y = [0.0, 1.0, 0.0, 1.0];
+        header.srow_z = [0.0, 0.0, 1.0, 1.0];
+        header.qform_code = 0;
+        header.quatern_b = 0.0;
+        header.quatern_c = 1.0;
+        header.quatern_d = 0.0;
+        header.quatern_x = 59.0;
+        header.quatern_y = 73.0;
+        header.quatern_z = 43.0;
+
+        assert_eq!(header.affine(), Affine4::new(
+            -0.9, 0.0, 0.0,   44.55,
+            0.0,  0.9, 0.0,  -44.55,
+            0.0,  0.0, 3.0, -148.5,
+            0.0, 0.0, 0.0, 1.0
+        ));
+    }
+}


### PR DESCRIPTION
Fix #22. Adds 2 public methods to `NiftiHeader` and a lot of other methods/functions in `header.rs` and `affine.rs`. This is mostly a port from NiBabel because:

- I don't actually know how quaternion works
- NiBabel has been tested extensively, by us and the whole community.

We (at Imeka) have been testing this port for more than 6 months now and we're quite happy with it. The code was in our open sourced project called [trk-io](https://github.com/imeka/trk-io/blob/master/src/affine_nifti.rs). I simply cleaned it, moved some functions to methods, etc.

I do have some questions though:

- I'm still unsure what should be public. `get_affine` and `set_affine` is the bare minimum and this is what I choosed. It might be a good idea to set the 'sform' and 'qform' methods public too.
- You know from my previous contributions that I don't use `Error` much. I prefer the `panic` alternative, but I know you will tell me to use `Error` :)
- I did everything in f32 but it should either be templated (to avoid forcing the users to convert their matrices) or in f64 (the math, at least). I'll probably do that in my next version.
- I hate formatting when I use matrices! Continued below.

I know I can use `#[rustfmt::skip]` on construction, but I don't like to see those things in my code. And you can't use it when you return a variable :| I tried using `from_rows` to avoid long lines but some lines in some matrices are still too long. I simply called rustfmt on `header.rs` and `affine.rs`, then I reverted the changes on the matrices because it's unreadable. You might disagree on this subject, I'm interested to know your opition.

    Affine4::from_rows(
        Vector4::new(m[0] as f32, m[3] as f32, m[6] as f32, self.quatern_x),
        Vector4::new(m[1] as f32, m[4] as f32, m[7] as f32, self.quatern_y),
        Vector4::new(m[2] as f32, m[5] as f32, m[8] as f32, self.quatern_z),
        Vector4::new(0.0, 0.0, 0.0, 1.0),
    )