### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,15 +24,15 @@ num = "0.2.0"
 num-derive = "0.2.0"
 num-traits = "0.2.0"
 quick-error = "1.2.0"
-safe-transmute = "0.9.0"
+safe-transmute = "0.10.1"
 
 [dependencies.alga]
 optional = true
-version = "0.7"
+version = "0.8"
 
 [dependencies.nalgebra]
 optional = true
-version = "0.16"
+version = "0.17"
 
 [dependencies.ndarray]
 optional = true
@@ -40,7 +40,7 @@ version = ">=0.10.12,<0.13.0"
 
 [dev-dependencies]
 approx = "0.3.0"
-pretty_assertions = "0.5.0"
+pretty_assertions = "0.6.1"
 tempfile = "3.0"
 
 [[example]]


### PR DESCRIPTION
- `alga` to 0.8, `nalgebra` to 0.17; the [release notes](https://www.nalgebra.org/changelog/) are outdated, but nothing appears to break here.
- `safe-transmute` to 0.10.1; not very important at this point, but not problematic either.
- dev dependency: `pretty_asserts`; release notes say that it's mostly a bug fixing release, so all is well.