### PR TITLE
Update manifest to exclude test resources

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ name = "nifti"
 readme = "README.md"
 repository = "https://github.com/Enet4/nifti-rs"
 version = "0.7.1-alpha.0"
+exclude = ["resources/*"]
 
 [badges]
 


### PR DESCRIPTION
Well, it turns out that without explicitly excluding this folder, the crate that is published on crates.io will include all of our NIfTI test files, even when they are not necessary. This tweak should significantly reduce the crate's size.