### PR TITLE
Migrate to Rust 2018 Edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Eduardo Pinho <enet4mikeenet@gmail.com>"]
 categories = ["parser-implementations"]
 description = "Rust implementation of the NIfTI file format"
 documentation = "https://docs.rs/crate/nifti"
+edition = "2018"
 keywords = ["nifti", "neuroimaging", "standard", "parser"]
 license = "MIT/Apache-2.0"
 name = "nifti"
@@ -10,6 +11,9 @@ readme = "README.md"
 repository = "https://github.com/Enet4/nifti-rs"
 version = "0.7.1-alpha.0"
 exclude = ["resources/*"]
+
+[package.metadata.docs.rs]
+features = ["ndarray_volumes"]
 
 [badges]
 
@@ -51,6 +55,3 @@ path = "examples/niftidump/main.rs"
 [features]
 nalgebra_affine = ["alga", "nalgebra"]
 ndarray_volumes = ["ndarray"]
-
-[package.metadata.docs.rs]
-features = ["ndarray_volumes"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 //! Types for error handling go here.
+use quick_error::quick_error;
 use std::io::Error as IOError;
-use typedef::NiftiType;
+use crate::typedef::NiftiType;
 
 quick_error! {
     /// Error type for all error variants originated by this crate.

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -5,7 +5,7 @@
 //! other than 0.
 
 use byteordered::{ByteOrdered, Endian};
-use error::{NiftiError, Result};
+use crate::error::{NiftiError, Result};
 use std::io::{ErrorKind as IoErrorKind, Read};
 
 /// Data type for the extender code.

--- a/src/header.rs
+++ b/src/header.rs
@@ -2,11 +2,14 @@
 //! to provide important information about NIFTI-1 volumes.
 
 #[cfg(feature = "nalgebra_affine")]
-use affine::*;
+use crate::affine::*;
 #[cfg(feature = "nalgebra_affine")]
 use alga::general::SubsetOf;
 use byteordered::{ByteOrdered, Endian, Endianness};
-use error::{NiftiError, Result};
+use crate::error::{NiftiError, Result};
+use crate::typedef::*;
+use crate::util::{is_gz_file, validate_dim, validate_dimensionality};
+use derive_builder::Builder;
 use flate2::bufread::GzDecoder;
 #[cfg(feature = "nalgebra_affine")]
 use nalgebra::{Matrix3, Matrix4, Quaternion, RealField, Vector3};
@@ -17,8 +20,6 @@ use std::fs::File;
 use std::io::{BufReader, Read};
 use std::ops::Deref;
 use std::path::Path;
-use typedef::*;
-use util::{is_gz_file, validate_dim, validate_dimensionality};
 
 /// Magic code for NIFTI-1 header files (extention ".hdr[.gz]").
 pub const MAGIC_CODE_NI1: &'static [u8; 4] = b"ni1\0";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,18 +65,7 @@
 #![warn(missing_docs, unused_extern_crates, trivial_casts, unused_results)]
 #![recursion_limit = "128"]
 
-#[macro_use] extern crate quick_error;
-#[macro_use] extern crate num_derive;
-#[macro_use] extern crate derive_builder;
-#[cfg(feature = "nalgebra_affine")] extern crate alga;
-#[cfg(feature = "nalgebra_affine")] extern crate nalgebra;
-#[cfg(feature = "ndarray_volumes")] extern crate ndarray;
 #[cfg(all(test, feature = "nalgebra_affine"))] #[macro_use] extern crate approx;
-
-extern crate byteordered;
-extern crate flate2;
-extern crate num_traits;
-extern crate safe_transmute;
 
 #[cfg(feature = "nalgebra_affine")] pub mod affine;
 pub mod extension;

--- a/src/object.rs
+++ b/src/object.rs
@@ -345,7 +345,7 @@ impl<V> GenericNiftiObject<V> {
 
             let ext = {
                 let stream = ByteOrdered::runtime(&mut stream, header.endianness);
-                ExtensionSequence::from_stream(extender, stream, len)?
+                ExtensionSequence::from_reader(extender, stream, len)?
             };
 
             let volume = FromSource::from_reader(stream, &header, options)?;
@@ -412,7 +412,7 @@ impl<V> GenericNiftiObject<V> {
             let len = if len < 352 { 0 } else { len - 352 };
 
             let ext = {
-                let mut stream = ByteOrdered::runtime(&mut stream, header.endianness);
+                let stream = ByteOrdered::runtime(&mut stream, header.endianness);
                 ExtensionSequence::from_reader(extender, stream, len)?
             };
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -1,19 +1,19 @@
 //! Module for handling and retrieving complete NIFTI-1 objects.
 
 use byteordered::ByteOrdered;
-use error::NiftiError;
-use error::Result;
-use extension::{Extender, ExtensionSequence};
+use crate::error::NiftiError;
+use crate::error::Result;
+use crate::extension::{Extender, ExtensionSequence};
+use crate::header::NiftiHeader;
+use crate::header::MAGIC_CODE_NI1;
+use crate::util::{into_img_file_gz, is_gz_file, open_file_maybe_gz};
+use crate::volume::inmem::InMemNiftiVolume;
+use crate::volume::streamed::StreamedNiftiVolume;
+use crate::volume::{FromSource, FromSourceOptions, NiftiVolume};
 use flate2::bufread::GzDecoder;
-use header::NiftiHeader;
-use header::MAGIC_CODE_NI1;
 use std::fs::File;
 use std::io::{self, BufReader, Read};
 use std::path::Path;
-use util::{into_img_file_gz, is_gz_file, open_file_maybe_gz};
-use volume::inmem::InMemNiftiVolume;
-use volume::streamed::StreamedNiftiVolume;
-use volume::{FromSource, FromSourceOptions, NiftiVolume};
 
 /// Trait type for all possible implementations of
 /// owning NIFTI-1 objects. Objects contain a NIFTI header,
@@ -344,8 +344,8 @@ impl<V> GenericNiftiObject<V> {
             let len = if len < 352 { 0 } else { len - 352 };
 
             let ext = {
-                let mut stream = ByteOrdered::runtime(&mut stream, header.endianness);
-                ExtensionSequence::from_reader(extender, stream, len)?
+                let stream = ByteOrdered::runtime(&mut stream, header.endianness);
+                ExtensionSequence::from_stream(extender, stream, len)?
             };
 
             let volume = FromSource::from_reader(stream, &header, options)?;

--- a/src/typedef.rs
+++ b/src/typedef.rs
@@ -4,12 +4,13 @@
 //! reading voxel values). However, primitive integer values can be
 //! converted to these types and vice-versa.
 
-use byteordered::{Endian, Endianness};
-use error::{NiftiError, Result};
-use num_traits::AsPrimitive;
+use crate::volume::element::{DataElement, LinearTransform};
+use crate::error::{NiftiError, Result};
 use std::io::Read;
 use std::ops::{Add, Mul};
-use volume::element::{DataElement, LinearTransform};
+use byteordered::{Endian, Endianness};
+use num_derive::FromPrimitive;
+use num_traits::AsPrimitive;
 
 /// Data type for representing a NIFTI value type in a volume.
 /// Methods for reading values of that type from a source are also included.

--- a/src/util.rs
+++ b/src/util.rs
@@ -9,9 +9,8 @@ use flate2::read::GzDecoder;
 use safe_transmute::{transmute_vec, TriviallyTransmutable};
 use super::typedef::NiftiType;
 use super::error::NiftiError;
-
-use error::Result;
-use NiftiHeader;
+use crate::error::Result;
+use crate::NiftiHeader;
 
 /// A trait that is both Read and Seek.
 pub trait ReadSeek: Read + Seek {}
@@ -174,8 +173,8 @@ mod tests {
     use super::{into_img_file_gz, is_gz_file, nb_bytes_for_dim_datatype};
     #[cfg(feature = "ndarray_volumes")]
     use super::is_hdr_file;
+    use crate::typedef::NiftiType;
     use std::path::PathBuf;
-    use typedef::NiftiType;
 
     #[test]
     fn test_nbytes() {

--- a/src/volume/element.rs
+++ b/src/volume/element.rs
@@ -2,14 +2,14 @@
 //! volume API implementations to read, write and convert data
 //! elements.
 use byteordered::{ByteOrdered, Endian};
-use error::Result;
+use crate::NiftiType;
+use crate::error::Result;
+use crate::util::convert_bytes_to;
 use num_traits::cast::AsPrimitive;
 use safe_transmute::transmute_vec;
 use std::io::Read;
 use std::mem::align_of;
 use std::ops::{Add, Mul};
-use util::convert_bytes_to;
-use NiftiType;
 
 /// Interface for linear (affine) transformations to values. Multiple
 /// implementations are needed because the original type `T` may not have

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -1,26 +1,26 @@
 //! Module holding an in-memory implementation of a NIfTI volume.
 
+use byteordered::{ByteOrdered, Endianness};
+use crate::error::{NiftiError, Result};
+use crate::extension::{Extender, ExtensionSequence};
+use crate::header::NiftiHeader;
+use crate::typedef::NiftiType;
+use crate::util::{nb_bytes_for_data, nb_bytes_for_dim_datatype};
+use crate::volume::element::DataElement;
+use crate::volume::{FromSource, FromSourceOptions, NiftiVolume, RandomAccessNiftiVolume};
 use super::shape::Dim;
 use super::util::coords_to_index;
-use super::{NiftiVolume, RandomAccessNiftiVolume};
-use byteordered::Endianness;
-use error::{NiftiError, Result};
 use flate2::bufread::GzDecoder;
-use header::NiftiHeader;
 use num_traits::{AsPrimitive, Num};
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::ops::{Add, Mul};
 use std::path::Path;
-use typedef::NiftiType;
-use util::{nb_bytes_for_data, nb_bytes_for_dim_datatype};
-use volume::element::DataElement;
-use volume::{FromSource, FromSourceOptions};
 
 #[cfg(feature = "ndarray_volumes")]
 use ndarray::{Array, Ix, IxDyn, ShapeBuilder};
 #[cfg(feature = "ndarray_volumes")]
-use volume::ndarray::IntoNdArray;
+use super::ndarray::IntoNdArray;
 
 /// A data type for a NIFTI-1 volume contained in memory. Objects of this type
 /// contain raw image data, which is converted automatically when using reading
@@ -208,7 +208,7 @@ impl InMemNiftiVolume {
         I: AsPrimitive<O>,
         O: DataElement,
     {
-        use volume::element::LinearTransform;
+        use crate::volume::element::LinearTransform;
 
         let dim: Vec<_> = self.dim().iter().map(|d| *d as Ix).collect();
 
@@ -415,9 +415,9 @@ impl<'a> RandomAccessNiftiVolume for &'a InMemNiftiVolume {
 mod tests {
     use super::*;
     use byteordered::Endianness;
-    use typedef::NiftiType;
-    use volume::shape::Dim;
-    use volume::Sliceable;
+    use crate::typedef::NiftiType;
+    use crate::volume::shape::Dim;
+    use crate::volume::Sliceable;
 
     #[test]
     fn test_u8_inmem_volume() {

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -1,8 +1,7 @@
 //! Module holding an in-memory implementation of a NIfTI volume.
 
-use byteordered::{ByteOrdered, Endianness};
+use byteordered::{Endianness};
 use crate::error::{NiftiError, Result};
-use crate::extension::{Extender, ExtensionSequence};
 use crate::header::NiftiHeader;
 use crate::typedef::NiftiType;
 use crate::util::{nb_bytes_for_data, nb_bytes_for_dim_datatype};

--- a/src/volume/mod.rs
+++ b/src/volume/mod.rs
@@ -13,10 +13,10 @@ pub use self::inmem::*;
 pub use self::streamed::StreamedNiftiVolume;
 
 mod util;
-use error::{NiftiError, Result};
-use header::NiftiHeader;
+use crate::error::{NiftiError, Result};
+use crate::header::NiftiHeader;
+use crate::typedef::NiftiType;
 use std::io::Read;
-use typedef::NiftiType;
 
 #[cfg(feature = "ndarray_volumes")]
 pub mod ndarray;

--- a/src/volume/ndarray.rs
+++ b/src/volume/ndarray.rs
@@ -25,12 +25,12 @@
 //! [`Array`]: ../../../ndarray/type.Array.html
 //! [element type]: ../element/trait.DataElement.html
 //!
-use error::Result;
+use crate::error::Result;
+use crate::volume::element::DataElement;
+use crate::volume::NiftiVolume;
 use ndarray::{Array, Axis, Ix, IxDyn};
 use num_traits::AsPrimitive;
 use std::ops::{Add, Mul};
-use volume::element::DataElement;
-use volume::NiftiVolume;
 
 /// Trait for volumes which can be converted to an ndarray.
 ///

--- a/src/volume/shape.rs
+++ b/src/volume/shape.rs
@@ -8,8 +8,8 @@
 //!
 //! [`Dim`]: ./struct.Dim.html
 //! [`Idx`]: ./struct.Idx.html
-use error::{NiftiError, Result};
-use util::{validate_dim, validate_dimensionality};
+use crate::error::{NiftiError, Result};
+use crate::util::{validate_dim, validate_dimensionality};
 
 /// A validated N-dimensional index in the NIfTI format.
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]

--- a/src/volume/streamed.rs
+++ b/src/volume/streamed.rs
@@ -58,14 +58,14 @@
 use super::inmem::InMemNiftiVolume;
 use super::shape::{Dim, Idx};
 use super::{FromSource, FromSourceOptions, NiftiVolume};
+use crate::error::Result;
+use crate::header::NiftiHeader;
+use crate::typedef::NiftiType;
+use crate::util::nb_bytes_for_dim_datatype;
 use byteordered::Endianness;
-use error::Result;
-use header::NiftiHeader;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::Path;
-use typedef::NiftiType;
-use util::nb_bytes_for_dim_datatype;
 
 /// A NIfTI-1 volume instance that is read slice by slice from a byte stream.
 ///
@@ -311,9 +311,9 @@ mod tests {
 
     use super::super::{NiftiVolume, RandomAccessNiftiVolume};
     use super::StreamedNiftiVolume;
+    use crate::typedef::NiftiType;
+    use crate::NiftiHeader;
     use byteordered::Endianness;
-    use typedef::NiftiType;
-    use NiftiHeader;
 
     #[test]
     fn test_streamed_base() {

--- a/src/volume/util.rs
+++ b/src/volume/util.rs
@@ -1,5 +1,5 @@
 //! Miscellaneous volume-related functions
-use error::{NiftiError, Result};
+use crate::error::{NiftiError, Result};
 use num_traits::Zero;
 
 pub fn hot_vector<T>(dim: usize, axis: usize, value: T) -> Vec<T>

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -10,7 +10,7 @@ use flate2::Compression;
 use ndarray::{ArrayBase, Axis, Data, Dimension, RemoveAxis};
 use safe_transmute::{transmute_to_bytes, TriviallyTransmutable};
 
-use {
+use crate::{
     header::{MAGIC_CODE_NI1, MAGIC_CODE_NIP1},
     util::{adapt_bytes, is_gz_file, is_hdr_file},
     volume::element::DataElement,


### PR DESCRIPTION
The minimum required compiler version is already way beyond 1.31 with the latest updates, so we might as well benefit from the latest edition.