### PR TITLE
Use Either type to reduce object impl redundancy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ num-derive = "0.2.0"
 num-traits = "0.2.0"
 quick-error = "1.2.0"
 safe-transmute = "0.11.0-rc.1"
+either = "1.5.2"
 
 [dependencies.alga]
 optional = true


### PR DESCRIPTION
This makes a significant improvement in the maintainability of the `object` module.
By including the `either` crate, we obtain a sum type for data which may be conditionally GZip encoded, that still implements `Read`.

Minor caveat: this now uses the `Either` type for reading the volume's data, even for in-memory volumes. This should hopefully not introduce a noticeable overhead.