### PR TITLE
ndarray 0.13 + build_dim_array

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ branch = "master"
 repository = "Enet4/nifti-rs"
 
 [dependencies]
+approx = "0.3"
 byteordered = "0.4.0"
 flate2 = "1.0.1"
 num = "0.2.0"
@@ -41,10 +42,10 @@ version = "0.18"
 
 [dependencies.ndarray]
 optional = true
-version = ">=0.10.12,<0.13.0"
+version = "0.13"
+features = ["approx"]
 
 [dev-dependencies]
-approx = "0.3.0"
 pretty_assertions = "0.6.1"
 tempfile = "3.0"
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -550,26 +550,6 @@ impl NiftiHeader {
     }
 }
 
-/// Build the `dim` field of the `NiftiHeader` from a ndarray shape.
-///
-/// # Example
-///
-/// ```
-/// use ndarray::Array3;
-/// use nifti::header::build_dim_array;
-/// let im = Array3::<f32>::zeros((3, 4, 5));
-/// assert_eq!(build_dim_array(im.shape()), [3, 3, 4, 5, 1, 1, 1, 1]);
-/// ```
-#[cfg(feature = "ndarray_volumes")]
-pub fn build_dim_array(data_shape: &[usize]) -> [u16; 8] {
-    let mut dim = [1; 8];
-    dim[0] = data_shape.len() as u16;
-    for (i, s) in data_shape.iter().enumerate() {
-        dim[i + 1] = *s as u16;
-    }
-    dim
-}
-
 fn parse_header_1<S>(input: S) -> Result<NiftiHeader>
 where
     S: Read,

--- a/src/header.rs
+++ b/src/header.rs
@@ -386,23 +386,12 @@ impl NiftiHeader {
         T: RealField,
         f32: SubsetOf<T>,
     {
+        #[rustfmt::skip]
         let affine = Matrix4::new(
-            self.srow_x[0],
-            self.srow_x[1],
-            self.srow_x[2],
-            self.srow_x[3],
-            self.srow_y[0],
-            self.srow_y[1],
-            self.srow_y[2],
-            self.srow_y[3],
-            self.srow_z[0],
-            self.srow_z[1],
-            self.srow_z[2],
-            self.srow_z[3],
-            0.0,
-            0.0,
-            0.0,
-            1.0,
+            self.srow_x[0], self.srow_x[1], self.srow_x[2], self.srow_x[3],
+            self.srow_y[0], self.srow_y[1], self.srow_y[2], self.srow_y[3],
+            self.srow_z[0], self.srow_z[1], self.srow_z[2], self.srow_z[3],
+            0.0, 0.0, 0.0, 1.0,
         );
         nalgebra::convert(affine)
     }
@@ -427,23 +416,12 @@ impl NiftiHeader {
             self.pixdim[3] as f64 * self.pixdim[0] as f64,
         ));
         let m = r * s;
+        #[rustfmt::skip]
         let affine = Matrix4::new(
-            m[0],
-            m[3],
-            m[6],
-            self.quatern_x as f64,
-            m[1],
-            m[4],
-            m[7],
-            self.quatern_y as f64,
-            m[2],
-            m[5],
-            m[8],
-            self.quatern_z as f64,
-            0.0,
-            0.0,
-            0.0,
-            1.0,
+            m[0], m[3], m[6], self.quatern_x as f64,
+            m[1], m[4], m[7], self.quatern_y as f64,
+            m[2], m[5], m[8], self.quatern_z as f64,
+            0.0, 0.0, 0.0, 1.0,
         );
         nalgebra::convert(affine)
     }
@@ -533,16 +511,11 @@ impl NiftiHeader {
             (aff2[3] + aff2[4] + aff2[5]).sqrt(),
             (aff2[6] + aff2[7] + aff2[8]).sqrt(),
         );
+        #[rustfmt::skip]
         let mut r = Matrix3::new(
-            affine[0] / spacing.0,
-            affine[3] / spacing.1,
-            affine[6] / spacing.2,
-            affine[1] / spacing.0,
-            affine[4] / spacing.1,
-            affine[7] / spacing.2,
-            affine[2] / spacing.0,
-            affine[5] / spacing.1,
-            affine[8] / spacing.2,
+            affine[0] / spacing.0, affine[3] / spacing.1, affine[6] / spacing.2,
+            affine[1] / spacing.0, affine[4] / spacing.1, affine[7] / spacing.2,
+            affine[2] / spacing.0, affine[5] / spacing.1, affine[8] / spacing.2,
         );
 
         // Set qfac to make R determinant positive

--- a/src/volume/ndarray.rs
+++ b/src/volume/ndarray.rs
@@ -78,6 +78,6 @@ where
     {
         // TODO optimize this implementation (we don't need the whole volume)
         let volume = self.volume.into_ndarray()?;
-        Ok(volume.into_subview(Axis(self.axis as Ix), self.index as usize))
+        Ok(volume.index_axis_move(Axis(self.axis as Ix), self.index as usize))
     }
 }

--- a/src/volume/shape.rs
+++ b/src/volume/shape.rs
@@ -8,6 +8,8 @@
 //!
 //! [`Dim`]: ./struct.Dim.html
 //! [`Idx`]: ./struct.Idx.html
+use num_traits::AsPrimitive;
+
 use crate::error::{NiftiError, Result};
 use crate::util::{validate_dim, validate_dimensionality};
 
@@ -137,14 +139,17 @@ impl Dim {
     /// assert_eq!(dim.as_ref(), &[64, 32, 16]);
     /// # Ok::<(), nifti::NiftiError>(())
     /// ```
-    pub fn from_slice(dim: &[u16]) -> Result<Self> {
+    pub fn from_slice<T>(dim: &[T]) -> Result<Self>
+    where
+        T: 'static + Copy + AsPrimitive<u16>,
+    {
         if dim.len() == 0 || dim.len() > 7 {
             return Err(NiftiError::InconsistentDim(0, dim.len() as u16));
         }
-        let mut raw = [0; 8];
+        let mut raw = [1; 8];
         raw[0] = dim.len() as u16;
         for (i, d) in dim.iter().enumerate() {
-            raw[i + 1] = *d;
+            raw[i + 1] = d.as_();
         }
         let _ = validate_dim(&raw)?;
         Ok(Dim(Idx(raw)))

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -11,10 +11,10 @@ use ndarray::{ArrayBase, Axis, Data, Dimension, RemoveAxis};
 use safe_transmute::{transmute_to_bytes, TriviallyTransmutable};
 
 use crate::{
-    header::{build_dim_array, MAGIC_CODE_NI1, MAGIC_CODE_NIP1},
+    header::{MAGIC_CODE_NI1, MAGIC_CODE_NIP1},
     util::{adapt_bytes, is_gz_file, is_hdr_file},
-    volume::element::DataElement,
-    NiftiHeader, NiftiType, Result,
+    volume::shape::Dim,
+    DataElement, NiftiHeader, NiftiType, Result,
 };
 
 /// Write a nifti file (.nii or .nii.gz).
@@ -176,7 +176,7 @@ where
     };
 
     let mut header = NiftiHeader {
-        dim: build_dim_array(data.shape()),
+        dim: *Dim::from_slice(data.shape())?.raw(),
         sizeof_hdr: 348,
         datatype: datatype as i16,
         bitpix: (datatype.size_of() * 8) as i16,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -11,7 +11,7 @@ use ndarray::{ArrayBase, Axis, Data, Dimension, RemoveAxis};
 use safe_transmute::{transmute_to_bytes, TriviallyTransmutable};
 
 use crate::{
-    header::{MAGIC_CODE_NI1, MAGIC_CODE_NIP1},
+    header::{build_dim_array, MAGIC_CODE_NI1, MAGIC_CODE_NIP1},
     util::{adapt_bytes, is_gz_file, is_hdr_file},
     volume::element::DataElement,
     NiftiHeader, NiftiType, Result,
@@ -165,12 +165,6 @@ where
     T: Data,
     D: Dimension,
 {
-    let mut dim = [1; 8];
-    dim[0] = data.ndim() as u16;
-    for (i, s) in data.shape().iter().enumerate() {
-        dim[i + 1] = *s as u16;
-    }
-
     // If no reference header is given, use the default.
     let reference = match reference {
         Some(r) => r.clone(),
@@ -182,7 +176,7 @@ where
     };
 
     let mut header = NiftiHeader {
-        dim,
+        dim: build_dim_array(data.shape()),
         sizeof_hdr: 348,
         datatype: datatype as i16,
         bitpix: (datatype.size_of() * 8) as i16,

--- a/tests/writer.rs
+++ b/tests/writer.rs
@@ -17,7 +17,8 @@ mod tests {
         path::{Path, PathBuf},
     };
 
-    use ndarray::{s, Array, Array2, Axis, Dimension, IxDyn, ShapeBuilder};
+    use approx::assert_abs_diff_eq;
+    use ndarray::{s, Array, Array1, Array2, Axis, Dimension, Ix2, IxDyn, ShapeBuilder};
     use num_traits::AsPrimitive;
     use tempfile::tempdir;
 
@@ -81,7 +82,7 @@ mod tests {
         (header, dyn_data.into_dimensionality::<D>().unwrap())
     }
 
-    fn test_write_read(arr: &Array<f32, IxDyn>, path: &str) {
+    fn test_write_read(arr: Array<f32, IxDyn>, path: &str) {
         let path = get_temporary_path(path);
         let mut dim = [1; 8];
         dim[0] = arr.ndim() as u16;
@@ -91,8 +92,9 @@ mod tests {
         let header = generate_nifti_header(dim, 1.0, 0.0, NiftiType::Float32);
         write_nifti(&path, &arr, Some(&header)).unwrap();
 
+        let gt = arr.into_dimensionality::<Ix2>().unwrap();
         let read_nifti: Array2<f32> = read_as_ndarray(path).1;
-        assert!(read_nifti.all_close(&arr, 1e-10));
+        assert_abs_diff_eq!(read_nifti, gt, epsilon = 1e-10);
     }
 
     fn f_order_array() -> Array<f32, IxDyn> {
@@ -111,36 +113,36 @@ mod tests {
     fn fortran_writing() {
         // Test .nii
         let arr = f_order_array();
-        test_write_read(&arr, "test.nii");
+        test_write_read(arr, "test.nii");
         let mut arr = f_order_array();
         arr.invert_axis(Axis(1));
-        test_write_read(&arr, "test_non_contiguous.nii");
+        test_write_read(arr, "test_non_contiguous.nii");
 
         // Test .nii.gz
         let arr = f_order_array();
-        test_write_read(&arr, "test.nii.gz");
+        test_write_read(arr, "test.nii.gz");
         let mut arr = f_order_array();
         arr.invert_axis(Axis(1));
-        test_write_read(&arr, "test_non_contiguous.nii.gz");
+        test_write_read(arr, "test_non_contiguous.nii.gz");
     }
 
     #[test]
     fn c_writing() {
         // Test .nii
         let arr = c_order_array();
-        test_write_read(&arr, "test.nii");
+        test_write_read(arr, "test.nii");
 
         let mut arr = c_order_array();
         arr.invert_axis(Axis(1));
-        test_write_read(&arr, "test_non_contiguous.nii");
+        test_write_read(arr, "test_non_contiguous.nii");
 
         // Test .nii.gz
         let arr = c_order_array();
-        test_write_read(&arr, "test.nii.gz");
+        test_write_read(arr, "test.nii.gz");
 
         let mut arr = c_order_array();
         arr.invert_axis(Axis(1));
-        test_write_read(&arr, "test_non_contiguous.nii.gz");
+        test_write_read(arr, "test_non_contiguous.nii.gz");
     }
 
     #[test]
@@ -159,13 +161,17 @@ mod tests {
         let transformed_data = arr.mul(slope).add(inter);
         write_nifti(&path, &transformed_data, Some(&header)).unwrap();
 
+        let gt = transformed_data.into_dimensionality::<Ix2>().unwrap();
         let read_nifti: Array2<f32> = read_as_ndarray(path).1;
-        assert!(read_nifti.all_close(&transformed_data, 1e-10));
+        assert_abs_diff_eq!(read_nifti, gt, epsilon = 1e-10);
     }
 
     #[test]
     fn half_slope() {
-        let data = Array::from_iter(0..216).into_shape((6, 6, 6)).unwrap();
+        let data = (0..216)
+            .collect::<Array1<_>>()
+            .into_shape((6, 6, 6))
+            .unwrap();
         let dim = [3, 6, 6, 6, 1, 1, 1, 1];
         let slope = 0.4;
         let inter = 100.1;
@@ -200,11 +206,13 @@ mod tests {
 
         let path = get_temporary_path("non_contiguous_0.nii.gz");
         write_nifti(&path, &data.slice(s![.., .., ..;2]), None).unwrap();
-        assert_eq!(read_as_ndarray(path).1, Array::from_elem((3, 4, 6), 42.0));
+        let loaded_data = read_as_ndarray::<_, f32, _>(path).1;
+        assert_eq!(loaded_data, Array::from_elem((3, 4, 6), 42.0));
 
         let path = get_temporary_path("non_contiguous_1.nii.gz");
         write_nifti(&path, &data.slice(s![.., .., 1..;2]), None).unwrap();
-        assert_eq!(read_as_ndarray(path).1, Array::from_elem((3, 4, 5), 1.5));
+        let loaded_data = read_as_ndarray::<_, f32, _>(path).1;
+        assert_eq!(loaded_data, Array::from_elem((3, 4, 5), 1.5));
     }
 
     #[test]
@@ -227,14 +235,14 @@ mod tests {
         // set_description
         header.set_description("ひらがな".as_bytes()).unwrap();
         write_nifti(&path, &data, Some(&header)).unwrap();
-        let (new_header, new_data) = read_as_ndarray(&path);
+        let (new_header, new_data) = read_as_ndarray::<_, f32, _>(&path);
         assert_eq!(new_header, header);
         assert_eq!(new_data, data);
 
         // set_description_str
         header.set_description_str("русский").unwrap();
         write_nifti(&path, &data, Some(&header)).unwrap();
-        let (new_header, new_data) = read_as_ndarray(&path);
+        let (new_header, new_data) = read_as_ndarray::<_, f32, _>(&path);
         assert_eq!(new_header, header);
         assert_eq!(new_data, data);
     }

--- a/tests/writer.rs
+++ b/tests/writer.rs
@@ -23,8 +23,9 @@ mod tests {
     use tempfile::tempdir;
 
     use nifti::{
-        header::{build_dim_array, MAGIC_CODE_NI1, MAGIC_CODE_NIP1},
+        header::{MAGIC_CODE_NI1, MAGIC_CODE_NIP1},
         object::NiftiObject,
+        volume::shape::Dim,
         writer::{write_nifti, write_rgb_nifti},
         DataElement, InMemNiftiObject, IntoNdArray, NiftiHeader, NiftiType,
     };
@@ -84,7 +85,7 @@ mod tests {
 
     fn test_write_read(arr: Array<f32, IxDyn>, path: &str) {
         let path = get_temporary_path(path);
-        let dim = build_dim_array(arr.shape());
+        let dim = *Dim::from_slice(arr.shape()).unwrap().raw();
         let header = generate_nifti_header(dim, 1.0, 0.0, NiftiType::Float32);
         write_nifti(&path, &arr, Some(&header)).unwrap();
 
@@ -148,7 +149,7 @@ mod tests {
         let inter = 101.1;
 
         let path = get_temporary_path("test_slope_inter.nii");
-        let dim = build_dim_array(arr.shape());
+        let dim = *Dim::from_slice(arr.shape()).unwrap().raw();
         let header = generate_nifti_header(dim, slope, inter, NiftiType::Float32);
         let transformed_data = arr.mul(slope).add(inter);
         write_nifti(&path, &transformed_data, Some(&header)).unwrap();

--- a/tests/writer.rs
+++ b/tests/writer.rs
@@ -23,7 +23,7 @@ mod tests {
     use tempfile::tempdir;
 
     use nifti::{
-        header::{MAGIC_CODE_NI1, MAGIC_CODE_NIP1},
+        header::{build_dim_array, MAGIC_CODE_NI1, MAGIC_CODE_NIP1},
         object::NiftiObject,
         writer::{write_nifti, write_rgb_nifti},
         DataElement, InMemNiftiObject, IntoNdArray, NiftiHeader, NiftiType,
@@ -84,11 +84,7 @@ mod tests {
 
     fn test_write_read(arr: Array<f32, IxDyn>, path: &str) {
         let path = get_temporary_path(path);
-        let mut dim = [1; 8];
-        dim[0] = arr.ndim() as u16;
-        for (i, s) in arr.shape().iter().enumerate() {
-            dim[i + 1] = *s as u16;
-        }
+        let dim = build_dim_array(arr.shape());
         let header = generate_nifti_header(dim, 1.0, 0.0, NiftiType::Float32);
         write_nifti(&path, &arr, Some(&header)).unwrap();
 
@@ -152,11 +148,7 @@ mod tests {
         let inter = 101.1;
 
         let path = get_temporary_path("test_slope_inter.nii");
-        let mut dim = [1; 8];
-        dim[0] = arr.ndim() as u16;
-        for (i, s) in arr.shape().iter().enumerate() {
-            dim[i + 1] = *s as u16;
-        }
+        let dim = build_dim_array(arr.shape());
         let header = generate_nifti_header(dim, slope, inter, NiftiType::Float32);
         let transformed_data = arr.mul(slope).add(inter);
         write_nifti(&path, &transformed_data, Some(&header)).unwrap();


### PR DESCRIPTION
Fix #58 

- Update to ndarray 0.13 and required fixes (from_iter, all_close and approx). Version 0.13 is now required for nifiti-rs.
- As discussed, I moved the approx crate from "dependencies" to "dev-dependencies".
- There some autoformat in this PR. I added `#[rustfmt::skip]` 3 times to avoid matrix formatting. I think formatting in Rust is great but not for matrices! I don't like using skip, but I consider it essential for matrices.
- The `Create build_dim_array function` commit doesn't fit in this PR, sorry. I'm not a fan of creating PR for tiny changes like that, but maybe you prefer it cleanly separated. Just tell me and I won't do it again :)