### PR TITLE
Dimension 1 bug

### DIFF
--- a/tests/util.rs
+++ b/tests/util.rs
@@ -3,7 +3,7 @@ use nifti::{Endianness, NiftiHeader, NiftiType};
 /// Known meta-data for the "minimal.nii" test file.
 #[allow(dead_code)]
 pub fn minimal_header_nii_gt() -> NiftiHeader {
-     NiftiHeader {
+    NiftiHeader {
         vox_offset: 352.,
         magic: *b"n+1\0",
         ..minimal_header_hdr_gt()
@@ -12,7 +12,7 @@ pub fn minimal_header_nii_gt() -> NiftiHeader {
 
 /// Known meta-data for the "minimal.hdr" test file.
 pub fn minimal_header_hdr_gt() -> NiftiHeader {
-     NiftiHeader {
+    NiftiHeader {
         sizeof_hdr: 348,
         dim: [3, 64, 64, 10, 0, 0, 0, 0],
         datatype: NiftiType::Uint8 as i16,


### PR DESCRIPTION
I'm not entirely happy with this fix because I don't understand why it works :| It make sense that writing the data bytes of a (1, 5, 5, 5) image is the same as writing them for a (5, 5, 5) image. The first dimension adds nothing interesting that should concern the `write_data` function. However, it looks like iterating on a dim=1 change the ordering. When I skip the dim=1, it works as intended.

Anyway, I'm still pushing this branch because I have other things to do, but if you have a better understanding of the problem than me, I'm interested!

Fix #63 