### PR TITLE
Remove Error descriptions

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -11,13 +11,12 @@ quick_error! {
         /// This is detected when reading the file's magic code,
         /// which should be either `b"ni1\0"` or `b"n+1\0`.
         InvalidFormat {
-            description("Invalid NIfTI-1 file")
+            display("Invalid NIfTI-1 file")
         }
         /// The field `dim` is in an invalid state, as a consequence of
         /// `dim[0]` or one of the elements in `1..dim[0] + 1` not being
         /// positive.
         InconsistentDim(index: u8, value: u16) {
-            description("Inconsistent dim in file header")
             display("Inconsistent value `{}` in header field dim[{}] ({})", value, index, match index {
                 0 if *value > 7 => "must not be higher than 7",
                 _ => "must be positive"
@@ -26,56 +25,52 @@ quick_error! {
         
         /// Attempted to read volume outside boundaries.
         OutOfBounds(coords: Vec<u16>) {
-            description("Out of bounds access to volume")
+            display("Out of bounds access to volume: {:?}", &coords[..])
         }
         /// Attempted to read a volume over a volume's unexistent dimension.
         AxisOutOfBounds(axis: u16) {
-            description("Out of bounds access to volume")
+            display("Out of bounds access to volume (axis {})", axis)
         }
         /// Could not retrieve a volume file based on the given header file.
         MissingVolumeFile(err: IOError) {
             cause(err)
-            description("Volume file not found")
+            display("Volume file not found")
         }
         /// An attempt to read a complete NIFTI-1 object from a header file
         /// was made. It can also be triggered when a NIFTI object contains
         /// the magic code "ni-1\0", even if the following bytes contain the volume.
         NoVolumeData {
-            description("No volume data available")
+            display("No volume data available")
         }
         /// An incorrect number of dimensions was provided when interacting
         /// with a volume.
         IncorrectVolumeDimensionality(expected: u16, got: u16) {
-            description("Unexpected volume data dimensionality")
+            display("Unexpected volume data dimensionality (expected {}, got {})", expected, got)
         }
         /// Inconsistent or unsupported volume size (due to one or more
         /// dimensions being too large).
         BadVolumeSize {
-            description("Bad volume size")
+            display("Bad volume size")
         }
         /// This voxel data type is not supported. Sorry. :(
         UnsupportedDataType(t: NiftiType) {
-            description("Unsupported data type")
+            display("Unsupported data type")
         }
         /// I/O Error
         Io(err: IOError) {
             from()
             cause(err)
-            description(err.description())
         }
         /// Raw data buffer length and volume dimensions are incompatible
         IncompatibleLength(got: usize, expected: usize) {
-            description("The buffer length and the header dimensions are incompatible.")
             display("The buffer length ({}) and header dimensions ({} elements) are incompatible", got, expected)
         }
         /// Description length must be lower than or equal to 80 bytes
         IncorrectDescriptionLength(len: usize) {
-            description("Description length is greater than 80 bytes.")
             display("Description length ({} bytes) is greater than 80 bytes.", len)
         }
         /// Header contains a code which is not valid for the given attribute
         InvalidCode(typename: &'static str, code: i16) {
-            description("invalid code")
             display("invalid code `{}` for header field {}", code, typename)
         }
     }


### PR DESCRIPTION
The method [`Error.description`](https://doc.rust-lang.org/stable/std/error/trait.Error.html#method.description) has been deprecated, so it's safe for `nifti` to follow suit by ensuring that a proper display message is presented without it.

These minor changes replace some of these `description` clauses from the `quick_error` macro into `display()`, and remove the rest. It is a backwards compatible change as long as users did not rely on this description in some way.