### PR TITLE
Less dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ repository = "Enet4/nifti-rs"
 approx = "0.3"
 byteordered = "0.4.0"
 flate2 = "1.0.1"
-num = "0.2.0"
 num-derive = "0.3.0"
 num-traits = "0.2.0"
 quick-error = "1.2.0"
@@ -33,10 +32,12 @@ safe-transmute = "0.11.0-rc.1"
 either = "1.5.2"
 
 [dependencies.alga]
+default-features = false
 optional = true
 version = "0.9"
 
 [dependencies.nalgebra]
+default-features = false
 optional = true
 version = "0.18"
 


### PR DESCRIPTION
Remove num and some default features. Not much but a `cargo build --release --features ...` was 2.5s faster on my work computer.

I tried getting rid of `nalgebra` because it's huge, I'm not using much of it (3x3 and 4x4 matrix, inverse, eigen and SVD) and we need to update it from time to time ... but it seems like an impossible job. The best I could find was `default-features = false` and it's not doing much!

I'll send a `nalgebra` update PR soon (0.18 to 0.21), if it's ok with you. EDIT: we might as well update all dependencies...