### PR TITLE
Support NIFTI_XFORM_TEMPLATE_OTHER 

### DIFF
--- a/src/typedef.rs
+++ b/src/typedef.rs
@@ -439,6 +439,8 @@ pub enum XForm {
     Talairach = 3,
     /// MNI 152 normalized coordinates.
     Mni152 = 4,
+    /// Normalized coordinates (for any general standard template space).
+    TemplateOther = 5,
 }
 
 /// An enum type for representing the slice order.


### PR DESCRIPTION
According to the official [implementation](https://nifti.nimh.nih.gov/pub/dist/src/niftilib/nifti1.h), there's a missing XForm in nifti-rs.

    /*!  Normalized coordinates (for any general standard template space). Added March 8, 2019. */
    #define NIFTI_XFORM_TEMPLATE_OTHER  5

Moreover, NiBabel supports it.