### PR TITLE
Public sform/qform affine

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -381,7 +381,7 @@ impl NiftiHeader {
     }
 
     /// Retrieve affine transformation from 'sform' fields.
-    fn sform_affine<T>(&self) -> Matrix4<T>
+    pub fn sform_affine<T>(&self) -> Matrix4<T>
     where
         T: RealField,
         f32: SubsetOf<T>,
@@ -397,7 +397,7 @@ impl NiftiHeader {
     }
 
     /// Retrieve affine transformation from qform-related fields.
-    fn qform_affine<T>(&self) -> Matrix4<T>
+    pub fn qform_affine<T>(&self) -> Matrix4<T>
     where
         T: RealField,
     {


### PR DESCRIPTION
I realized while working in another project that making those functions public was more practical than modifying both `code`s and calling `affine()` to get one affine, then changing both codes again to get the other affine.