### PR TITLE
Add ReaderOptions and ReaderStreamedOptions

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -240,6 +240,16 @@ impl NiftiHeader {
         parse_header_1(input)
     }
 
+    /// Fix some commonly invalid fields.
+    ///
+    /// Currently, only the following problems are fixed:
+    /// - If `pixdim[0]` isn't equal to -1.0 or 1.0, it will be set to 1.0
+    pub fn fix(&mut self) {
+        if self.pixdim[0].abs() != 1.0 {
+            self.pixdim[0] = 1.0;
+        }
+    }
+
     /// Retrieve and validate the dimensions of the volume. Unlike how NIfTI-1
     /// stores dimensions, the returned slice does not include `dim[0]` and is
     /// clipped to the effective number of dimensions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,11 @@
 //! # Example
 //!
 //! ```no_run
-//! use nifti::{NiftiObject, InMemNiftiObject, NiftiVolume};
+//! use nifti::{NiftiObject, ReaderOptions, NiftiVolume};
 //! # use nifti::error::Result;
 //!
 //! # fn run() -> Result<()> {
-//! let obj = InMemNiftiObject::from_file("myvolume.nii.gz")?;
+//! let obj = ReaderOptions::new().read_file("myvolume.nii.gz")?;
 //! // use obj
 //! let header = obj.header();
 //! let volume = obj.volume();
@@ -20,10 +20,10 @@
 //! specifying just the header file:
 //!
 //! ```no_run
-//! use nifti::{NiftiObject, InMemNiftiObject};
+//! use nifti::{NiftiObject, ReaderOptions};
 //! # use nifti::error::Result;
 //! # fn run() -> Result<()> {
-//! let obj = InMemNiftiObject::from_file("myvolume.hdr.gz")?;
+//! let obj = ReaderOptions::new().read_file("myvolume.hdr.gz")?;
 //! # Ok(())
 //! # }
 //! ```
@@ -37,9 +37,9 @@
 //! # use nifti::error::Result;
 //! # #[cfg(feature = "ndarray_volumes")]
 //! # fn run() -> Result<()> {
-//! # use nifti::{NiftiObject, InMemNiftiObject};
+//! # use nifti::{NiftiObject, ReaderOptions};
 //! use nifti::IntoNdArray;
-//! # let obj = InMemNiftiObject::from_file("myvolume.hdr.gz").unwrap();
+//! # let obj = ReaderOptions::new().read_file("myvolume.hdr.gz").unwrap();
 //! let volume = obj.into_volume().into_ndarray::<f32>()?;
 //! # Ok(())
 //! # }
@@ -47,11 +47,11 @@
 //!
 //! An additional volume API is also available for reading large volumes slice
 //! by slice.
-//! 
+//!
 //! ```no_run
-//! # use nifti::{NiftiObject, StreamedNiftiObject};
+//! # use nifti::{NiftiObject, ReaderStreamedOptions};
 //! # use nifti::error::NiftiError;
-//! let obj = StreamedNiftiObject::from_file("minimal.nii.gz")?;
+//! let obj = ReaderStreamedOptions::new().read_file("minimal.nii.gz")?;
 //!
 //! let volume = obj.into_volume();
 //! for slice in volume {
@@ -65,24 +65,33 @@
 #![warn(missing_docs, unused_extern_crates, trivial_casts, unused_results)]
 #![recursion_limit = "128"]
 
-#[cfg(all(test, feature = "nalgebra_affine"))] #[macro_use] extern crate approx;
+#[cfg(all(test, feature = "nalgebra_affine"))]
+#[macro_use]
+extern crate approx;
 
-#[cfg(feature = "nalgebra_affine")] pub mod affine;
+#[cfg(feature = "nalgebra_affine")]
+pub mod affine;
+pub mod error;
 pub mod extension;
 pub mod header;
 pub mod object;
-pub mod volume;
-pub mod error;
 pub mod typedef;
-#[cfg(feature = "ndarray_volumes")] pub mod writer;
 mod util;
+pub mod volume;
+#[cfg(feature = "ndarray_volumes")]
+pub mod writer;
 
+pub use byteordered::Endianness;
 pub use error::{NiftiError, Result};
-pub use object::{NiftiObject, InMemNiftiObject, StreamedNiftiObject};
 pub use extension::{Extender, Extension, ExtensionSequence};
 pub use header::NiftiHeader;
-pub use volume::{NiftiVolume, RandomAccessNiftiVolume, InMemNiftiVolume, StreamedNiftiVolume, Sliceable};
+pub use object::{
+    InMemNiftiObject, NiftiObject, ReaderOptions, ReaderStreamedOptions, StreamedNiftiObject,
+};
+pub use typedef::{Intent, NiftiType, SliceOrder, Unit, XForm};
 pub use volume::element::DataElement;
-#[cfg(feature = "ndarray_volumes")] pub use volume::ndarray::IntoNdArray;
-pub use typedef::{NiftiType, Unit, Intent, XForm, SliceOrder};
-pub use byteordered::Endianness;
+#[cfg(feature = "ndarray_volumes")]
+pub use volume::ndarray::IntoNdArray;
+pub use volume::{
+    InMemNiftiVolume, NiftiVolume, RandomAccessNiftiVolume, Sliceable, StreamedNiftiVolume,
+};

--- a/src/object.rs
+++ b/src/object.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 pub use crate::util::{GzDecodedFile, MaybeGzDecodedFile};
 
 /// Options and flags which can be used to configure how a NIfTI image is read.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ReaderOptions {
     /// Whether to automatically fix value in the header
     fix_header: bool,
@@ -94,7 +94,7 @@ impl ReaderOptions {
 }
 
 /// Options and flags which can be used to configure how a NIfTI image is read and iterated.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ReaderStreamedOptions {
     /// Whether to automatically fix value in the header
     fix_header: bool,

--- a/src/object.rs
+++ b/src/object.rs
@@ -304,7 +304,10 @@ impl InMemNiftiObject {
     /// let obj = InMemNiftiObject::from_file("minimal.nii.gz")?;
     /// # Ok::<(), nifti::NiftiError>(())
     /// ```
-    #[deprecated(note = "use `read_file` from `ReaderOptions` instead")]
+    #[deprecated(
+        since = "0.10.0",
+        note = "use `read_file` from `ReaderOptions` instead"
+    )]
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         let gz = is_gz_file(&path);
 
@@ -319,7 +322,10 @@ impl InMemNiftiObject {
     /// Retrieve a NIFTI object as separate header and volume files.
     /// This method is useful when file names are not conventional for a
     /// NIFTI file pair.
-    #[deprecated(note = "use `read_file_pair` from `ReaderOptions` instead")]
+    #[deprecated(
+        since = "0.10.0",
+        note = "use `read_file_pair` from `ReaderOptions` instead"
+    )]
     pub fn from_file_pair<P, Q>(hdr_path: P, vol_path: Q) -> Result<Self>
     where
         P: AsRef<Path>,
@@ -362,7 +368,10 @@ impl StreamedNiftiObject<MaybeGzDecodedFile> {
     /// }
     /// # Ok::<(), nifti::NiftiError>(())
     /// ```
-    #[deprecated(note = "use `read_file` from `ReaderStreamedOptions` instead")]
+    #[deprecated(
+        since = "0.10.0",
+        note = "use `read_file` from `ReaderStreamedOptions` instead"
+    )]
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         let reader = open_file_maybe_gz(&path)?;
         Self::from_file_impl(path, reader, None)
@@ -374,7 +383,10 @@ impl StreamedNiftiObject<MaybeGzDecodedFile> {
     /// If the file only contains the header, this method will
     /// look for the corresponding file with the extension ".img",
     /// or ".img.gz" if the former wasn't found.
-    #[deprecated(note = "use `read_file_rank` from `ReaderStreamedOptions` instead")]
+    #[deprecated(
+        since = "0.10.0",
+        note = "use `read_file_rank` from `ReaderStreamedOptions` instead"
+    )]
     pub fn from_file_rank<P: AsRef<Path>>(path: P, slice_rank: u16) -> Result<Self> {
         let reader = open_file_maybe_gz(&path)?;
         Self::from_file_impl(path, reader, Some(slice_rank))
@@ -398,7 +410,10 @@ impl StreamedNiftiObject<MaybeGzDecodedFile> {
     /// }
     /// # Ok::<(), nifti::NiftiError>(())
     /// ```
-    #[deprecated(note = "use `read_file_pair` from `ReaderStreamedOptions` instead")]
+    #[deprecated(
+        since = "0.10.0",
+        note = "use `read_file_pair` from `ReaderStreamedOptions` instead"
+    )]
     pub fn from_file_pair<P, Q>(hdr_path: P, vol_path: Q) -> Result<Self>
     where
         P: AsRef<Path>,
@@ -412,7 +427,10 @@ impl StreamedNiftiObject<MaybeGzDecodedFile> {
     /// streamed volume reading, using `slice_rank` as the dimensionality of
     /// each slice. This method is useful when file names are not conventional
     /// for a NIfTI file pair.
-    #[deprecated(note = "use `read_file_pair_rank` from `ReaderStreamedOptions` instead")]
+    #[deprecated(
+        since = "0.10.0",
+        note = "use `read_file_pair_rank` from `ReaderStreamedOptions` instead"
+    )]
     pub fn from_file_pair_rank<P, Q>(hdr_path: P, vol_path: Q, slice_rank: u16) -> Result<Self>
     where
         P: AsRef<Path>,

--- a/src/object.rs
+++ b/src/object.rs
@@ -63,7 +63,7 @@ impl ReaderOptions {
             InMemNiftiObject::from_file_impl(path, file, Default::default())
         }?;
         if self.fix_header {
-            apply_fix_on_header(&mut obj.header);
+            obj.header.fix();
         }
         Ok(obj)
     }
@@ -87,7 +87,7 @@ impl ReaderOptions {
             InMemNiftiObject::from_file_pair_impl(file, vol_path, Default::default())
         }?;
         if self.fix_header {
-            apply_fix_on_header(&mut obj.header);
+            obj.header.fix();
         }
         Ok(obj)
     }
@@ -141,7 +141,7 @@ impl ReaderStreamedOptions {
         let reader = open_file_maybe_gz(&path)?;
         let mut obj = StreamedNiftiObject::from_file_impl(path, reader, None)?;
         if self.fix_header {
-            apply_fix_on_header(&mut obj.header);
+            obj.header.fix();
         }
         Ok(obj)
     }
@@ -163,7 +163,7 @@ impl ReaderStreamedOptions {
         let reader = open_file_maybe_gz(&path)?;
         let mut obj = StreamedNiftiObject::from_file_impl(path, reader, Some(slice_rank))?;
         if self.fix_header {
-            apply_fix_on_header(&mut obj.header);
+            obj.header.fix();
         }
         Ok(obj)
     }
@@ -199,7 +199,7 @@ impl ReaderStreamedOptions {
         let mut obj =
             StreamedNiftiObject::from_file_pair_impl(reader, vol_path, Default::default())?;
         if self.fix_header {
-            apply_fix_on_header(&mut obj.header);
+            obj.header.fix();
         }
         Ok(obj)
     }
@@ -221,15 +221,9 @@ impl ReaderStreamedOptions {
         let reader = open_file_maybe_gz(hdr_path)?;
         let mut obj = StreamedNiftiObject::from_file_pair_impl(reader, vol_path, Some(slice_rank))?;
         if self.fix_header {
-            apply_fix_on_header(&mut obj.header);
+            obj.header.fix();
         }
         Ok(obj)
-    }
-}
-
-fn apply_fix_on_header(header: &mut NiftiHeader) {
-    if header.pixdim[0].abs() != 1.0 {
-        header.pixdim[0] = 1.0;
     }
 }
 

--- a/tests/object.rs
+++ b/tests/object.rs
@@ -6,8 +6,8 @@ extern crate nifti;
 extern crate pretty_assertions;
 
 use nifti::{
-    Endianness, InMemNiftiObject, StreamedNiftiObject, NiftiHeader, NiftiObject, NiftiType,
-    NiftiVolume, RandomAccessNiftiVolume, XForm,
+    Endianness, NiftiHeader, NiftiObject, NiftiType, NiftiVolume, RandomAccessNiftiVolume,
+    ReaderOptions, ReaderStreamedOptions, XForm,
 };
 
 mod util;
@@ -19,7 +19,7 @@ fn minimal_nii_gz() {
     let minimal_hdr = minimal_header_nii_gt();
 
     const FILE_NAME: &str = "resources/minimal.nii.gz";
-    let obj = InMemNiftiObject::from_file(FILE_NAME).unwrap();
+    let obj = ReaderOptions::new().read_file(FILE_NAME).unwrap();
     assert_eq!(obj.header(), &minimal_hdr);
     let volume = obj.volume();
     assert_eq!(volume.data_type(), NiftiType::Uint8);
@@ -31,7 +31,7 @@ fn streamed_minimal_nii_gz() {
     let minimal_hdr = minimal_header_nii_gt();
 
     const FILE_NAME: &str = "resources/minimal.nii.gz";
-    let obj = StreamedNiftiObject::from_file(FILE_NAME).unwrap();
+    let obj = ReaderStreamedOptions::new().read_file(FILE_NAME).unwrap();
     assert_eq!(obj.header(), &minimal_hdr);
     let volume = obj.volume();
     assert_eq!(volume.data_type(), NiftiType::Uint8);
@@ -43,7 +43,7 @@ fn minimal_nii() {
     let minimal_hdr = minimal_header_nii_gt();
 
     const FILE_NAME: &str = "resources/minimal.nii";
-    let obj = InMemNiftiObject::from_file(FILE_NAME).unwrap();
+    let obj = ReaderOptions::new().read_file(FILE_NAME).unwrap();
     assert_eq!(obj.header(), &minimal_hdr);
     let volume = obj.volume();
     assert_eq!(volume.data_type(), NiftiType::Uint8);
@@ -55,7 +55,7 @@ fn streamed_minimal_nii() {
     let minimal_hdr = minimal_header_nii_gt();
 
     const FILE_NAME: &str = "resources/minimal.nii";
-    let obj = StreamedNiftiObject::from_file(FILE_NAME).unwrap();
+    let obj = ReaderStreamedOptions::new().read_file(FILE_NAME).unwrap();
     assert_eq!(obj.header(), &minimal_hdr);
     let volume = obj.volume();
     assert_eq!(volume.data_type(), NiftiType::Uint8);
@@ -67,7 +67,7 @@ fn minimal_by_hdr() {
     let minimal_hdr = minimal_header_hdr_gt();
 
     const FILE_NAME: &str = "resources/minimal.hdr";
-    let obj = InMemNiftiObject::from_file(FILE_NAME).unwrap();
+    let obj = ReaderOptions::new().read_file(FILE_NAME).unwrap();
     assert_eq!(obj.header(), &minimal_hdr);
     let volume = obj.volume();
     assert_eq!(volume.data_type(), NiftiType::Uint8);
@@ -79,7 +79,7 @@ fn streamed_minimal_by_hdr() {
     let minimal_hdr = minimal_header_hdr_gt();
 
     const FILE_NAME: &str = "resources/minimal.hdr";
-    let obj = StreamedNiftiObject::from_file(FILE_NAME).unwrap();
+    let obj = ReaderStreamedOptions::new().read_file(FILE_NAME).unwrap();
     assert_eq!(obj.header(), &minimal_hdr);
     let volume = obj.volume();
     assert_eq!(volume.data_type(), NiftiType::Uint8);
@@ -92,7 +92,7 @@ fn minimal_by_hdr_and_img_gz() {
 
     const FILE_NAME: &str = "resources/minimal2.hdr";
     // should attempt to read "resources/minimal2.img.gz"
-    let obj = InMemNiftiObject::from_file(FILE_NAME).unwrap();
+    let obj = ReaderOptions::new().read_file(FILE_NAME).unwrap();
     assert_eq!(obj.header(), &minimal_hdr);
     let volume = obj.volume();
     assert_eq!(volume.data_type(), NiftiType::Uint8);
@@ -104,7 +104,7 @@ fn minimal_by_hdr_gz() {
     let minimal_hdr = minimal_header_hdr_gt();
 
     const FILE_NAME: &str = "resources/minimal.hdr.gz";
-    let obj = InMemNiftiObject::from_file(FILE_NAME).unwrap();
+    let obj = ReaderOptions::new().read_file(FILE_NAME).unwrap();
     assert_eq!(obj.header(), &minimal_hdr);
     let volume = obj.volume();
     assert_eq!(volume.data_type(), NiftiType::Uint8);
@@ -117,7 +117,9 @@ fn minimal_by_pair() {
 
     const HDR_FILE_NAME: &str = "resources/minimal.hdr.gz";
     const IMG_FILE_NAME: &str = "resources/minimal.img.gz";
-    let obj = InMemNiftiObject::from_file_pair(HDR_FILE_NAME, IMG_FILE_NAME).unwrap();
+    let obj = ReaderOptions::new()
+        .read_file_pair(HDR_FILE_NAME, IMG_FILE_NAME)
+        .unwrap();
     assert_eq!(obj.header(), &minimal_hdr);
     let volume = obj.volume();
     assert_eq!(volume.data_type(), NiftiType::Uint8);
@@ -145,7 +147,7 @@ fn f32_nii_gz() {
     };
 
     const FILE_NAME: &str = "resources/f32.nii.gz";
-    let obj = InMemNiftiObject::from_file(FILE_NAME).unwrap();
+    let obj = ReaderOptions::new().read_file(FILE_NAME).unwrap();
     assert_eq!(obj.header(), &f32_hdr);
 
     assert_eq!(obj.header().sform().unwrap(), XForm::AlignedAnat);
@@ -183,7 +185,7 @@ fn streamed_f32_nii_gz() {
     };
 
     const FILE_NAME: &str = "resources/f32.nii.gz";
-    let obj = StreamedNiftiObject::from_file(FILE_NAME).unwrap();
+    let obj = ReaderStreamedOptions::new().read_file(FILE_NAME).unwrap();
     assert_eq!(obj.header(), &f32_hdr);
 
     assert_eq!(obj.header().sform().unwrap(), XForm::AlignedAnat);
@@ -212,24 +214,27 @@ fn streamed_f32_nii_gz() {
 
 #[test]
 fn bad_file_1() {
-    let _ = InMemNiftiObject::from_file("resources/fuzz_artifacts/crash-1.nii");
+    let _ = ReaderOptions::new().read_file("resources/fuzz_artifacts/crash-1.nii");
     // must not panic
 }
 
 #[test]
 fn bad_file_2() {
-    let _ = InMemNiftiObject::from_file("resources/fuzz_artifacts/crash-98aa054390f8d3f932f190dc22ef62c6ff2d6619");
+    let _ = ReaderOptions::new()
+        .read_file("resources/fuzz_artifacts/crash-98aa054390f8d3f932f190dc22ef62c6ff2d6619");
     // must not panic or abort
 }
 
 #[test]
 fn bad_file_3() {
-    let _ = InMemNiftiObject::from_file("resources/fuzz_artifacts/crash-d03c6346fe83a026738f6b8cd2a9335a3f8cb158");
+    let _ = ReaderOptions::new()
+        .read_file("resources/fuzz_artifacts/crash-d03c6346fe83a026738f6b8cd2a9335a3f8cb158");
     // must not panic or abort
 }
 
 #[test]
 fn bad_file_4() {
-    let _ = InMemNiftiObject::from_file("resources/fuzz_artifacts/crash-08123ef33416bd6f0c5fa63d44b681b8581d62a0");
+    let _ = ReaderOptions::new()
+        .read_file("resources/fuzz_artifacts/crash-08123ef33416bd6f0c5fa63d44b681b8581d62a0");
     // must not panic or abort
 }

--- a/tests/volume.rs
+++ b/tests/volume.rs
@@ -46,13 +46,15 @@ fn minimal_img_gz() {
 
 #[cfg(feature = "ndarray_volumes")]
 mod ndarray_volumes {
+    use super::util::minimal_header_hdr_gt;
+    use ndarray::{Array, Axis, IxDyn, ShapeBuilder};
+    use nifti::{
+        DataElement, InMemNiftiVolume, IntoNdArray, NiftiObject, NiftiType, NiftiVolume,
+        ReaderOptions, ReaderStreamedOptions,
+    };
+    use num_traits::AsPrimitive;
     use std::fmt;
     use std::ops::{Add, Mul};
-    use nifti::{DataElement, InMemNiftiObject, InMemNiftiVolume, IntoNdArray,
-                NiftiObject, NiftiType, NiftiVolume, StreamedNiftiObject};
-    use ndarray::{Array, Axis, IxDyn, ShapeBuilder};
-    use num_traits::AsPrimitive;
-    use super::util::minimal_header_hdr_gt;
 
     #[test]
     fn minimal_img_gz_ndarray_f32() {
@@ -109,7 +111,8 @@ mod ndarray_volumes {
     #[test]
     fn f32_nii_gz_ndarray() {
         const FILE_NAME: &str = "resources/f32.nii.gz";
-        let volume = InMemNiftiObject::from_file(FILE_NAME)
+        let volume = ReaderOptions::new()
+            .read_file(FILE_NAME)
             .unwrap()
             .into_volume();
         assert_eq!(volume.data_type(), NiftiType::Float32);
@@ -131,7 +134,8 @@ mod ndarray_volumes {
     #[test]
     fn f32_nii_gz_ndarray_f64() {
         const FILE_NAME: &str = "resources/f32.nii.gz";
-        let volume = InMemNiftiObject::from_file(FILE_NAME)
+        let volume = ReaderOptions::new()
+            .read_file(FILE_NAME)
             .unwrap()
             .into_volume();
         assert_eq!(volume.data_type(), NiftiType::Float32);
@@ -153,7 +157,8 @@ mod ndarray_volumes {
     #[test]
     fn streamed_f32_nii_gz_ndarray_f64() {
         const FILE_NAME: &str = "resources/f32.nii.gz";
-        let volume = StreamedNiftiObject::from_file(FILE_NAME)
+        let volume = ReaderStreamedOptions::new()
+            .read_file(FILE_NAME)
             .unwrap()
             .into_volume();
         assert_eq!(volume.data_type(), NiftiType::Float32);
@@ -269,7 +274,8 @@ mod ndarray_volumes {
         f64: AsPrimitive<T>,
         usize: AsPrimitive<T>,
     {
-        let volume = InMemNiftiObject::from_file(path)
+        let volume = ReaderOptions::new()
+            .read_file(path)
             .expect("Can't read input file.")
             .into_volume();
         assert_eq!(volume.data_type(), dtype);

--- a/tests/writer.rs
+++ b/tests/writer.rs
@@ -29,7 +29,7 @@ mod tests {
         object::NiftiObject,
         volume::shape::Dim,
         writer::{write_nifti, write_rgb_nifti},
-        DataElement, InMemNiftiObject, IntoNdArray, NiftiHeader, NiftiType,
+        DataElement, IntoNdArray, NiftiHeader, NiftiType, ReaderOptions,
     };
 
     use super::util::rgb_header_gt;
@@ -78,7 +78,9 @@ mod tests {
         f32: AsPrimitive<T>,
         f64: AsPrimitive<T>,
     {
-        let nifti_object = InMemNiftiObject::from_file(path).expect("Nifti file is unreadable.");
+        let nifti_object = ReaderOptions::new()
+            .read_file(path)
+            .expect("Nifti file is unreadable.");
         let header = nifti_object.header().clone();
         let volume = nifti_object.into_volume();
         let dyn_data = volume.into_ndarray::<T>().unwrap();


### PR DESCRIPTION
- Make InMemNiftiObject's methods privates
- Make StreamedNiftiObject's methods privates
- Remove the deprecated new_from_stream method
- Apply one fix on header when requested
- Fix all tests

Sorry, there was some automatic formatting when I saved (like in lib.rs). The other concerns I have at the moment are:
- One can still read the complete image by creating a File, reading the header, then reading the volume. Should I block that? By making some methods `pub crate` in `header.rs` and `volume/inmen.rs`?
- I don't want to block it too much because we want a way to read only the header without reading the complete image. We're already using this in our codebase. It's practical and much faster.
- I separated the features in `ReaderOptions` and `ReaderStreamedOptions` to avoid repetitive names `read_file_streamed/_rank/_pair/_pair_rank` (I can at least remove the 'streamed' in all names. But it does create some code copy. If we ever add some general methods, like `read_header`, the code will be exactly the same. So, I'm not sure it was the right decision.