### PR TITLE
Update crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,20 +31,20 @@ quick-error = "1.2"
 safe-transmute = "0.11"
 either = "1.5"
 
-[dependencies.alga]
-default-features = false
-optional = true
-version = "0.9"
-
 [dependencies.nalgebra]
 default-features = false
 optional = true
-version = "0.18"
+version = "0.21"
 
 [dependencies.ndarray]
 optional = true
 version = "0.13"
 features = ["approx"]
+
+[dependencies.simba]
+default-features = false
+optional = true
+version = "0.1"
 
 [dev-dependencies]
 pretty_assertions = "0.6"
@@ -55,5 +55,5 @@ name = "niftidump"
 path = "examples/niftidump/main.rs"
 
 [features]
-nalgebra_affine = ["alga", "nalgebra"]
+nalgebra_affine = ["nalgebra", "simba"]
 ndarray_volumes = ["ndarray"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,13 @@ repository = "Enet4/nifti-rs"
 
 [dependencies]
 approx = "0.3"
-byteordered = "0.4.0"
-flate2 = "1.0.1"
-num-derive = "0.3.0"
-num-traits = "0.2.0"
-quick-error = "1.2.0"
-safe-transmute = "0.11.0-rc.1"
-either = "1.5.2"
+byteordered = "0.5"
+flate2 = "1.0"
+num-derive = "0.3"
+num-traits = "0.2"
+quick-error = "1.2"
+safe-transmute = "0.11"
+either = "1.5"
 
 [dependencies.alga]
 default-features = false
@@ -47,8 +47,8 @@ version = "0.13"
 features = ["approx"]
 
 [dev-dependencies]
-pretty_assertions = "0.6.1"
-tempfile = "3.0"
+pretty_assertions = "0.6"
+tempfile = "3.1"
 
 [[example]]
 name = "niftidump"

--- a/src/affine.rs
+++ b/src/affine.rs
@@ -10,7 +10,10 @@ pub type Affine4 = Matrix4<f32>;
 const QUARTERNION_THRESHOLD: f64 = -::std::f32::EPSILON as f64 * 3.0;
 
 /// Separate a 4x4 affine into its 3x3 affine and translation components.
-pub fn affine_and_translation<T: Scalar>(affine: &Matrix4<T>) -> (Matrix3<T>, Vector3<T>) {
+pub fn affine_and_translation<T>(affine: &Matrix4<T>) -> (Matrix3<T>, Vector3<T>)
+where
+    T: Copy + Scalar,
+{
     let translation = Vector3::new(affine[12], affine[13], affine[14]);
     let affine = affine.fixed_slice::<U3, U3>(0, 0).into_owned();
     (affine, translation)
@@ -19,6 +22,7 @@ pub fn affine_and_translation<T: Scalar>(affine: &Matrix4<T>) -> (Matrix3<T>, Ve
 /// Get affine implied by given shape and zooms.
 ///
 /// We get the translations from the center of the image (implied by `shape`).
+#[rustfmt::skip]
 pub(crate) fn shape_zoom_affine(shape: &[u16], spacing: &[f32]) -> Matrix4<f64> {
     // Get translations from center of image
     let origin = Vector3::new(
@@ -70,6 +74,7 @@ pub(crate) fn fill_positive(xyz: Vector3<f64>) -> Quaternion<f64> {
 ///
 /// Bar-Itzhack, Itzhack Y. "New method for extracting the quaternion from a rotation
 /// matrix", AIAA Journal of Guidance, Control and Dynamics 23(6):1085-1087, 2000
+#[rustfmt::skip]
 pub(crate) fn affine_to_quaternion(affine: &Matrix3<f64>) -> RowVector4<f64> {
     // qyx refers to the contribution of the y input vector component to the x output vector
     // component. qyx is therefore the same as M[0, 1]. The notation is from the Wikipedia article.
@@ -121,6 +126,7 @@ pub(crate) fn affine_to_quaternion(affine: &Matrix3<f64>) -> RowVector4<f64> {
 /// The algorithm here allows non-unit quaternions.
 ///
 /// Algorithm from https://en.wikipedia.org/wiki/Rotation_matrix#Quaternion
+#[rustfmt::skip]
 pub(crate) fn quaternion_to_affine(q: Quaternion<f64>) -> Matrix3<f64> {
     let nq = q.w * q.w + q.i * q.i + q.j * q.j + q.k * q.k;
     if nq < ::std::f64::EPSILON {
@@ -151,6 +157,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[rustfmt::skip]
     fn test_shape_zoom_affine() {
         let affine = shape_zoom_affine(&[3, 5, 7], &[3.0, 2.0, 1.0]);
         let real_affine = Matrix4::new(

--- a/src/header.rs
+++ b/src/header.rs
@@ -6,8 +6,6 @@ use crate::affine::*;
 use crate::error::{NiftiError, Result};
 use crate::typedef::*;
 use crate::util::{is_gz_file, validate_dim, validate_dimensionality};
-#[cfg(feature = "nalgebra_affine")]
-use alga::general::SubsetOf;
 use byteordered::{ByteOrdered, Endian, Endianness};
 use flate2::bufread::GzDecoder;
 #[cfg(feature = "nalgebra_affine")]
@@ -15,6 +13,8 @@ use nalgebra::{Matrix3, Matrix4, Quaternion, RealField, Vector3};
 use num_traits::FromPrimitive;
 #[cfg(feature = "nalgebra_affine")]
 use num_traits::ToPrimitive;
+#[cfg(feature = "nalgebra_affine")]
+use simba::scalar::SubsetOf;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::ops::Deref;


### PR DESCRIPTION
I'm not sure if this is what you wanted but I updated all the crates
- using a X.Y versioning, not X.Y.Z, because I don't see the point of being explicit about the last number. Please educate me if I shouldn't have done that :)
- including `safe-transmute` which you just updated. Yay, no more RC crates.
- nalgebra required more changes, they dropped algo in favor of simba.
- I added some `#[rustfmt::skip]` because the matrices were auto-formatted. I hate that. I needed that add them on top of the functions, otherwise `attributes on expressions are experimental`. I hate that even more.

Did you have other goals before a release? We want to use nalgebra 0.21 but we depend on nifti-rs. I'm aware of #62 , but it could be a 0.10 release.