### PR TITLE
Remove stuff that was deprecated since 0.8.0

### DIFF
--- a/src/extension.rs
+++ b/src/extension.rs
@@ -17,25 +17,10 @@ pub struct Extender([u8; 4]);
 
 impl Extender {
     /// Fetch the extender code from the given source, while expecting it to exist.
-    #[deprecated(since = "0.8.0", note = "use `from_reader` instead")]
-    pub fn from_stream<S: Read>(source: S) -> Result<Self> {
-        Self::from_reader(source)
-    }
-
-    /// Fetch the extender code from the given source, while expecting it to exist.
     pub fn from_reader<S: Read>(mut source: S) -> Result<Self> {
         let mut extension = [0u8; 4];
         source.read_exact(&mut extension)?;
         Ok(extension.into())
-    }
-
-    /// Fetch the extender code from the given source, while
-    /// being possible to not be available.
-    /// Returns `None` if the source reaches EoF prematurely.
-    /// Any other I/O error is delegated to a `NiftiError`.
-    #[deprecated(since = "0.8.0", note = "use `from_reader_optional` instead")]
-    pub fn from_stream_optional<S: Read>(source: S) -> Result<Option<Self>> {
-        Self::from_reader_optional(source)
     }
 
     /// Fetch the extender code from the given source, while
@@ -148,20 +133,6 @@ impl<'a> IntoIterator for &'a ExtensionSequence {
 }
 
 impl ExtensionSequence {
-    /// Read a sequence of extensions from a source, up until `len` bytes.
-    #[deprecated(since = "0.8.0", note = "use `from_reader` instead")]
-    pub fn from_stream<S, E>(
-        extender: Extender,
-        source: ByteOrdered<S, E>,
-        len: usize,
-    ) -> Result<Self>
-    where
-        S: Read,
-        E: Endian,
-    {
-        Self::from_reader(extender, source, len)
-    }
-
     /// Read a sequence of extensions from a source, up until `len` bytes.
     pub fn from_reader<S, E>(
         extender: Extender,

--- a/src/header.rs
+++ b/src/header.rs
@@ -225,14 +225,6 @@ impl NiftiHeader {
     /// Read a NIfTI-1 header, along with its byte order, from the given byte stream.
     /// It is assumed that the input is currently at the start of the
     /// NIFTI header.
-    #[deprecated(since = "0.8.0", note = "use `from_reader` instead")]
-    pub fn from_stream<S: Read>(input: S) -> Result<NiftiHeader> {
-        Self::from_reader(input)
-    }
-
-    /// Read a NIfTI-1 header, along with its byte order, from the given byte stream.
-    /// It is assumed that the input is currently at the start of the
-    /// NIFTI header.
     pub fn from_reader<S>(input: S) -> Result<NiftiHeader>
     where
         S: Read,

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -99,15 +99,6 @@ impl InMemNiftiVolume {
     /// of the volume's data must be known in advance. It it also expected that the
     /// following bytes represent the first voxels of the volume (and not part of the
     /// extensions).
-    #[deprecated(since = "0.8.0", note = "use `from_reader` instead")]
-    pub fn from_stream<R: Read>(source: R, header: &NiftiHeader) -> Result<Self> {
-        Self::from_reader(source, header)
-    }
-
-    /// Read a NIFTI volume from a stream of data. The header and expected byte order
-    /// of the volume's data must be known in advance. It it also expected that the
-    /// following bytes represent the first voxels of the volume (and not part of the
-    /// extensions).
     pub fn from_reader<R: Read>(source: R, header: &NiftiHeader) -> Result<Self> {
         // rather than pre-allocating for the full volume size, this will
         // pre-allocate up to a more reliable amount and feed the vector


### PR DESCRIPTION
Should be safe to take them out at this point,
considering that they were hard-deprecated in 0.8 and 0.9.