### PR TITLE
Add the 7 optional FSL intents

### DIFF
--- a/src/typedef.rs
+++ b/src/typedef.rs
@@ -416,20 +416,20 @@ pub enum Intent {
     Shape = 2005,
 
     /// FSL FNIRT Displacement field.
-    FSLFNIRTDisplacementField = 2006,
+    FslFnirtDisplacementField = 2006,
     /// FSL Cubic spline coefficients.
-    FSLCubicSplineCoefficients = 2007,
+    FslCubicSplineCoefficients = 2007,
     /// FSL Discrete cosine transform coefficients.
-    FSLDCTCoefficients = 2008,
+    FslDctCoefficients = 2008,
     /// FSL Quadratic spline coefficients.
-    FSLQuadraticSplineCoefficients = 2009,
+    FslQuadraticSplineCoefficients = 2009,
 
     /// FSL Topup cubic spline coefficients.
-    FSLTopupCubicSplineCoefficients = 2016,
+    FslTopupCubicSplineCoefficients = 2016,
     /// FSL Topup quadratic spline coefficients.
-    FSLTopupQuadraticSplineCoefficients = 2017,
+    FslTopupQuadraticSplineCoefficients = 2017,
     /// FSL Topup field.
-    FSLTopupField = 2018,
+    FslTopupField = 2018,
 }
 
 impl Intent {

--- a/src/typedef.rs
+++ b/src/typedef.rs
@@ -4,13 +4,13 @@
 //! reading voxel values). However, primitive integer values can be
 //! converted to these types and vice-versa.
 
-use crate::volume::element::{DataElement, LinearTransform};
 use crate::error::{NiftiError, Result};
-use std::io::Read;
-use std::ops::{Add, Mul};
+use crate::volume::element::{DataElement, LinearTransform};
 use byteordered::{Endian, Endianness};
 use num_derive::FromPrimitive;
 use num_traits::AsPrimitive;
+use std::io::Read;
+use std::ops::{Add, Mul};
 
 /// Data type for representing a NIFTI value type in a volume.
 /// Methods for reading values of that type from a source are also included.
@@ -414,6 +414,22 @@ pub enum Intent {
     /// To signify that the value at each location is a shape value, such
     /// as the curvature.
     Shape = 2005,
+
+    /// FSL FNIRT Displacement field.
+    FSLFNIRTDisplacementField = 2006,
+    /// FSL Cubic spline coefficients.
+    FSLCubicSplineCoefficients = 2007,
+    /// FSL Discrete cosine transform coefficients.
+    FSLDCTCoefficients = 2008,
+    /// FSL Quadratic spline coefficients.
+    FSLQuadraticSplineCoefficients = 2009,
+
+    /// FSL Topup cubic spline coefficients.
+    FSLTopupCubicSplineCoefficients = 2016,
+    /// FSL Topup quadratic spline coefficients.
+    FSLTopupQuadraticSplineCoefficients = 2017,
+    /// FSL Topup field.
+    FSLTopupField = 2018,
 }
 
 impl Intent {


### PR DESCRIPTION
- Some automatic formatting in the `use`.
- I simply added the missing intents in the enum. I don't think there's anything else to do.
- There's no documentation in the standard for those fields, so I simply rewrote the name in a human readable way.
- I wasn't sure if `FSLFNIRTDisplacementField` or `FslFnirtDisplacementField` was better...?

Fix #73 