### PR TITLE
Writer options

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -17,196 +17,259 @@ use crate::{
     DataElement, NiftiHeader, NiftiType, Result,
 };
 
-/// Write a nifti file (.nii or .nii.gz).
-///
-/// If a `reference` is given, it will be used to fill most of the header's fields. Otherwise, a
-/// default `NiftiHeader` will be built and written. In all cases, the `dim`, `datatype` and
-/// `bitpix` fields will depend only on `data`, not on the header. This means that the `datatype`
-/// defined in `reference` will be ignored. Because of this, `scl_slope` will be set to 1.0 and
-/// `scl_inter` to 0.0.
-pub fn write_nifti<P, A, S, D>(
-    header_path: P,
-    data: &ArrayBase<S, D>,
-    reference: Option<&NiftiHeader>,
-) -> Result<()>
-where
-    P: AsRef<Path>,
-    S: Data<Elem = A>,
-    A: DataElement,
-    A: TriviallyTransmutable,
-    D: Dimension + RemoveAxis,
-{
-    let compression_level = Compression::fast();
-    let is_gz = is_gz_file(&header_path);
-    let (header, data_path) =
-        prepare_header_and_paths(&header_path, data, reference, A::DATA_TYPE)?;
+/// Options and flags which can be used to configure how a NIfTI image is written.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WriterOptions<'a> {
+    /// Where to write the output image (header and/or data).
+    header_path: PathBuf,
+    /// If given, it will be used to fill most of the header's fields. Otherwise, a default
+    /// `NiftiHeader` will be built and written. In all cases, the `dim`, `datatype` and `bitpix`
+    /// fields will depend only on `data` parameter passed to the `write` function, not on this
+    /// field. This means that the `datatype` defined in `reference` will be ignored. Because of
+    /// this, `scl_slope` will be set to 1.0 and `scl_inter` to 0.0.
+    reference: Option<&'a NiftiHeader>,
+    /// Whether to write the header and data in distinct files. (nii vs hdr+img)
+    header_file: bool,
+    /// Whether to compress the output to gz. Is guessed from the `header_path`, but can be
+    /// overriden with the `compress` method, which will update the `header_path` to keep coherency.
+    compress: bool,
+    /// Compression level to use when writing to the gz file.
+    compression_level: Compression,
+}
 
-    // Need the transpose for fortran ordering used in nifti file format.
-    let data = data.t();
-
-    let header_file = File::create(header_path)?;
-    if header.vox_offset > 0.0 {
-        if is_gz {
-            let mut writer = ByteOrdered::runtime(
-                GzEncoder::new(header_file, compression_level),
-                header.endianness,
-            );
-            write_header(writer.as_mut(), &header)?;
-            write_data::<_, A, _, _, _, _>(writer.as_mut(), data)?;
-            let _ = writer.into_inner().finish()?;
-        } else {
-            let mut writer = ByteOrdered::runtime(BufWriter::new(header_file), header.endianness);
-            write_header(writer.as_mut(), &header)?;
-            write_data::<_, A, _, _, _, _>(writer, data)?;
+impl<'a> WriterOptions<'a> {
+    /// Creates a blank new set of options ready for configuration.
+    pub fn new<P>(header_path: P) -> WriterOptions<'a>
+    where
+        P: AsRef<Path>,
+    {
+        let mut header_path = header_path.as_ref().to_owned();
+        if header_path.extension().is_none() {
+            let _ = header_path.set_extension("nii");
         }
-    } else {
-        let data_file = File::create(&data_path)?;
-        if is_gz {
-            let mut writer = ByteOrdered::runtime(
-                GzEncoder::new(header_file, compression_level),
-                header.endianness,
-            );
-            write_header(writer.as_mut(), &header)?;
-            let _ = writer.into_inner().finish()?;
-
-            let mut writer = ByteOrdered::runtime(
-                GzEncoder::new(data_file, compression_level),
-                header.endianness,
-            );
-            write_data::<_, A, _, _, _, _>(writer.as_mut(), data)?;
-            let _ = writer.into_inner().finish()?;
-        } else {
-            let header_writer =
-                ByteOrdered::runtime(BufWriter::new(header_file), header.endianness);
-            write_header(header_writer, &header)?;
-            let data_writer = ByteOrdered::runtime(BufWriter::new(data_file), header.endianness);
-            write_data::<_, A, _, _, _, _>(data_writer, data)?;
+        let header_file = is_hdr_file(&header_path);
+        let compress = is_gz_file(&header_path);
+        WriterOptions {
+            header_path,
+            reference: None,
+            header_file,
+            compress,
+            compression_level: Compression::fast(),
         }
     }
 
-    Ok(())
-}
-
-/// Write a RGB nifti file (.nii or .nii.gz).
-///
-/// If a `reference` is given, it will be used to fill most of the header's fields, except those
-/// necessary to be recognized as a RGB image. `scl_slope` will be set to 1.0 and `scl_inter` to
-/// 0.0. If `reference` is not given, a default `NiftiHeader` will be built and written.
-pub fn write_rgb_nifti<P, S, D>(
-    header_path: P,
-    data: &ArrayBase<S, D>,
-    reference: Option<&NiftiHeader>,
-) -> Result<()>
-where
-    P: AsRef<Path>,
-    S: Data<Elem = [u8; 3]>,
-    D: Dimension + RemoveAxis,
-{
-    let compression_level = Compression::fast();
-    let is_gz = is_gz_file(&header_path);
-    let (header, data_path) =
-        prepare_header_and_paths(&header_path, data, reference, NiftiType::Rgb24)?;
-
-    // Need the transpose for fortran used in nifti file format.
-    let data = data.t();
-
-    let header_file = File::create(header_path)?;
-    if header.vox_offset > 0.0 {
-        if is_gz {
-            let mut writer = ByteOrdered::runtime(
-                GzEncoder::new(header_file, compression_level),
-                header.endianness,
-            );
-            write_header(writer.as_mut(), &header)?;
-            write_data::<_, u8, _, _, _, _>(writer.as_mut(), data)?;
-            let _ = writer.into_inner().finish()?;
-        } else {
-            let mut writer = ByteOrdered::runtime(BufWriter::new(header_file), header.endianness);
-            write_header(writer.as_mut(), &header)?;
-            write_data::<_, u8, _, _, _, _>(writer, data)?;
-        }
-    } else {
-        let data_file = File::create(&data_path)?;
-        if is_gz {
-            let mut writer = ByteOrdered::runtime(
-                GzEncoder::new(header_file, compression_level),
-                header.endianness,
-            );
-            write_header(writer.as_mut(), &header)?;
-            let _ = writer.into_inner().finish()?;
-
-            let mut writer = ByteOrdered::runtime(
-                GzEncoder::new(data_file, compression_level),
-                header.endianness,
-            );
-            write_data::<_, u8, _, _, _, _>(writer.as_mut(), data)?;
-            let _ = writer.into_inner().finish()?;
-        } else {
-            let header_writer =
-                ByteOrdered::runtime(BufWriter::new(header_file), header.endianness);
-            write_header(header_writer, &header)?;
-
-            let data_writer = ByteOrdered::runtime(BufWriter::new(data_file), header.endianness);
-            write_data::<_, u8, _, _, _, _>(data_writer, data)?;
-        }
+    /// Sets the reference header to use instead of the default one.
+    pub fn reference(mut self, reference: &'a NiftiHeader) -> Self {
+        self.reference = Some(reference);
+        self
     }
 
-    Ok(())
-}
-
-fn prepare_header_and_paths<P, T, D>(
-    header_path: P,
-    data: &ArrayBase<T, D>,
-    reference: Option<&NiftiHeader>,
-    datatype: NiftiType,
-) -> Result<(NiftiHeader, PathBuf)>
-where
-    P: AsRef<Path>,
-    T: Data,
-    D: Dimension,
-{
-    // If no reference header is given, use the default.
-    let reference = match reference {
-        Some(r) => r.clone(),
-        None => {
-            let mut header = NiftiHeader::default();
-            header.sform_code = 2;
-            header
+    /// Whether to write the header and data in distinct files.
+    ///
+    /// Will update the output path accordingly.
+    pub fn header_file(mut self, header_file: bool) -> Self {
+        if self.header_file != header_file {
+            self.header_file = header_file;
+            self.fix_header_path_extension();
         }
-    };
+        self
+    }
 
-    let mut header = NiftiHeader {
-        dim: *Dim::from_slice(data.shape())?.raw(),
-        sizeof_hdr: 348,
-        datatype: datatype as i16,
-        bitpix: (datatype.size_of() * 8) as i16,
-        vox_offset: 352.0,
-        scl_inter: 0.0,
-        scl_slope: 1.0,
-        magic: *MAGIC_CODE_NIP1,
-        // All other fields are copied from reference header
-        ..reference
-    };
+    /// Whether to compress the output to gz.
+    ///
+    /// Will update the output path accordingly.
+    pub fn compress(mut self, compress: bool) -> Self {
+        if self.compress != compress {
+            self.compress = compress;
+            self.fix_header_path_extension();
+        }
+        self
+    }
 
-    // The only acceptable length is 80. If different, try to set it.
-    header.validate_description()?;
-
-    let mut path_buf = PathBuf::from(header_path.as_ref());
-    let data_path = if is_hdr_file(&header_path) {
-        header.vox_offset = 0.0;
-        header.magic = *MAGIC_CODE_NI1;
-        let data_path = if is_gz_file(&header_path) {
-            let _ = path_buf.set_extension("");
-            path_buf.with_extension("img.gz")
-        } else {
-            path_buf.with_extension("img")
+    /// Fix the header path extension in case a change in `header_file` or `compress` broke it.
+    fn fix_header_path_extension(&mut self) {
+        let _ = self.header_path.set_extension("");
+        self.header_path = match (self.header_file, self.compress) {
+            (false, false) => self.header_path.with_extension("nii"),
+            (false, true) => self.header_path.with_extension("nii.gz"),
+            (true, false) => self.header_path.with_extension("hdr"),
+            (true, true) => self.header_path.with_extension("hdr.gz"),
         };
-        data_path
-    } else {
-        path_buf
-    };
+    }
 
-    Ok((header, data_path))
+    /// Sets the compression level to use when compressing the output.
+    pub fn compression_level(mut self, compression_level: Compression) -> Self {
+        self.compression_level = compression_level;
+        self
+    }
+
+    /// Write a nifti file (.nii or .nii.gz).
+    pub fn write_nifti<A, S, D>(&self, data: &ArrayBase<S, D>) -> Result<()>
+    where
+        S: Data<Elem = A>,
+        A: DataElement,
+        A: TriviallyTransmutable,
+        D: Dimension + RemoveAxis,
+    {
+        let (header, data_path) = self.prepare_header_and_paths(data, A::DATA_TYPE)?;
+
+        // Need the transpose for fortran ordering used in nifti file format.
+        let data = data.t();
+
+        let header_file = File::create(&self.header_path)?;
+        if header.vox_offset > 0.0 {
+            if self.compress {
+                let mut writer = ByteOrdered::runtime(
+                    GzEncoder::new(header_file, self.compression_level),
+                    header.endianness,
+                );
+                write_header(writer.as_mut(), &header)?;
+                write_data::<_, A, _, _, _, _>(writer.as_mut(), data)?;
+                let _ = writer.into_inner().finish()?;
+            } else {
+                let mut writer =
+                    ByteOrdered::runtime(BufWriter::new(header_file), header.endianness);
+                write_header(writer.as_mut(), &header)?;
+                write_data::<_, A, _, _, _, _>(writer, data)?;
+            }
+        } else {
+            let data_file = File::create(&data_path)?;
+            if self.compress {
+                let mut writer = ByteOrdered::runtime(
+                    GzEncoder::new(header_file, self.compression_level),
+                    header.endianness,
+                );
+                write_header(writer.as_mut(), &header)?;
+                let _ = writer.into_inner().finish()?;
+
+                let mut writer = ByteOrdered::runtime(
+                    GzEncoder::new(data_file, self.compression_level),
+                    header.endianness,
+                );
+                write_data::<_, A, _, _, _, _>(writer.as_mut(), data)?;
+                let _ = writer.into_inner().finish()?;
+            } else {
+                let header_writer =
+                    ByteOrdered::runtime(BufWriter::new(header_file), header.endianness);
+                write_header(header_writer, &header)?;
+                let data_writer =
+                    ByteOrdered::runtime(BufWriter::new(data_file), header.endianness);
+                write_data::<_, A, _, _, _, _>(data_writer, data)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Write a RGB nifti file (.nii or .nii.gz).
+    pub fn write_rgb_nifti<S, D>(&self, data: &ArrayBase<S, D>) -> Result<()>
+    where
+        S: Data<Elem = [u8; 3]>,
+        D: Dimension + RemoveAxis,
+    {
+        let (header, data_path) = self.prepare_header_and_paths(data, NiftiType::Rgb24)?;
+
+        // Need the transpose for fortran used in nifti file format.
+        let data = data.t();
+
+        let header_file = File::create(&self.header_path)?;
+        if header.vox_offset > 0.0 {
+            if self.compress {
+                let mut writer = ByteOrdered::runtime(
+                    GzEncoder::new(header_file, self.compression_level),
+                    header.endianness,
+                );
+                write_header(writer.as_mut(), &header)?;
+                write_data::<_, u8, _, _, _, _>(writer.as_mut(), data)?;
+                let _ = writer.into_inner().finish()?;
+            } else {
+                let mut writer =
+                    ByteOrdered::runtime(BufWriter::new(header_file), header.endianness);
+                write_header(writer.as_mut(), &header)?;
+                write_data::<_, u8, _, _, _, _>(writer, data)?;
+            }
+        } else {
+            let data_file = File::create(&data_path)?;
+            if self.compress {
+                let mut writer = ByteOrdered::runtime(
+                    GzEncoder::new(header_file, self.compression_level),
+                    header.endianness,
+                );
+                write_header(writer.as_mut(), &header)?;
+                let _ = writer.into_inner().finish()?;
+
+                let mut writer = ByteOrdered::runtime(
+                    GzEncoder::new(data_file, self.compression_level),
+                    header.endianness,
+                );
+                write_data::<_, u8, _, _, _, _>(writer.as_mut(), data)?;
+                let _ = writer.into_inner().finish()?;
+            } else {
+                let header_writer =
+                    ByteOrdered::runtime(BufWriter::new(header_file), header.endianness);
+                write_header(header_writer, &header)?;
+
+                let data_writer =
+                    ByteOrdered::runtime(BufWriter::new(data_file), header.endianness);
+                write_data::<_, u8, _, _, _, _>(data_writer, data)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn prepare_header_and_paths<T, D>(
+        &self,
+        data: &ArrayBase<T, D>,
+        datatype: NiftiType,
+    ) -> Result<(NiftiHeader, PathBuf)>
+    where
+        T: Data,
+        D: Dimension,
+    {
+        // If no reference header is given, use the default.
+        let reference = match self.reference {
+            Some(r) => r.clone(),
+            None => {
+                let mut header = NiftiHeader::default();
+                header.sform_code = 2;
+                header
+            }
+        };
+
+        let mut header = NiftiHeader {
+            dim: *Dim::from_slice(data.shape())?.raw(),
+            sizeof_hdr: 348,
+            datatype: datatype as i16,
+            bitpix: (datatype.size_of() * 8) as i16,
+            vox_offset: 352.0,
+            scl_inter: 0.0,
+            scl_slope: 1.0,
+            magic: *MAGIC_CODE_NIP1,
+            // All other fields are copied from reference header
+            ..reference
+        };
+
+        // The only acceptable length is 80. If different, try to set it.
+        header.validate_description()?;
+
+        let mut path_buf = self.header_path.clone();
+        let data_path = if self.header_file {
+            header.vox_offset = 0.0;
+            header.magic = *MAGIC_CODE_NI1;
+            let data_path = if self.compress {
+                let _ = path_buf.set_extension("");
+                path_buf.with_extension("img.gz")
+            } else {
+                path_buf.with_extension("img")
+            };
+            data_path
+        } else {
+            path_buf
+        };
+
+        Ok((header, data_path))
+    }
 }
 
 fn write_header<W, E>(mut writer: ByteOrdered<W, E>, header: &NiftiHeader) -> Result<()>

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -392,3 +392,39 @@ where
     writer.write_all(&*bytes)?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_writer_path() {
+        let w = WriterOptions::new("~/image");
+        assert_eq!(w.header_path, PathBuf::from("~/image.nii"));
+
+        for (p, nii, niigz) in &[
+            ("~/image", "~/image.nii", "~/image.nii.gz"),
+            ("~/image.nii", "~/image.nii", "~/image.nii.gz"),
+            ("~/image.nii.gz", "~/image.nii", "~/image.nii.gz"),
+            ("~/image.hdr", "~/image.hdr", "~/image.hdr.gz"),
+            ("~/image.hdr.gz", "~/image.hdr", "~/image.hdr.gz"),
+        ] {
+            let nii = PathBuf::from(nii);
+            let niigz = PathBuf::from(niigz);
+
+            let w = WriterOptions::new(p).compress(true);
+            assert_eq!(w.header_path, niigz);
+            let w = WriterOptions::new(p).compress(true).compress(true);
+            assert_eq!(w.header_path, niigz);
+            let w = WriterOptions::new(p).compress(true).compress(false);
+            assert_eq!(w.header_path, nii);
+
+            let w = WriterOptions::new(p).compress(false);
+            assert_eq!(w.header_path, nii);
+            let w = WriterOptions::new(p).compress(false).compress(false);
+            assert_eq!(w.header_path, nii);
+            let w = WriterOptions::new(p).compress(false).compress(true);
+            assert_eq!(w.header_path, niigz);
+        }
+    }
+}

--- a/tests/writer.rs
+++ b/tests/writer.rs
@@ -92,7 +92,7 @@ mod tests {
         let dim = *Dim::from_slice(arr.shape()).unwrap().raw();
         let header = generate_nifti_header(dim, 1.0, 0.0, NiftiType::Float32);
         WriterOptions::new(&path)
-            .reference(&header)
+            .reference_header(&header)
             .write_nifti(&arr)
             .unwrap();
 
@@ -160,7 +160,7 @@ mod tests {
         let header = generate_nifti_header(dim, slope, inter, NiftiType::Float32);
         let transformed_data = arr.mul(slope).add(inter);
         WriterOptions::new(&path)
-            .reference(&header)
+            .reference_header(&header)
             .write_nifti(&transformed_data)
             .unwrap();
 
@@ -182,7 +182,7 @@ mod tests {
 
         let path = get_temporary_path("test_slope_inter.nii");
         WriterOptions::new(&path)
-            .reference(&header)
+            .reference_header(&header)
             .write_nifti(&data)
             .unwrap();
 
@@ -238,7 +238,7 @@ mod tests {
         let v = "äbcdé".as_bytes();
         header.descrip = v.to_vec();
         WriterOptions::new(&path)
-            .reference(&header)
+            .reference_header(&header)
             .write_nifti(&data)
             .unwrap();
         let (new_header, new_data) = read_as_ndarray::<_, f32, _>(&path);
@@ -249,7 +249,7 @@ mod tests {
         // set_description
         header.set_description("ひらがな".as_bytes()).unwrap();
         WriterOptions::new(&path)
-            .reference(&header)
+            .reference_header(&header)
             .write_nifti(&data)
             .unwrap();
         let (new_header, new_data) = read_as_ndarray::<_, f32, _>(&path);
@@ -259,7 +259,7 @@ mod tests {
         // set_description_str
         header.set_description_str("русский").unwrap();
         WriterOptions::new(&path)
-            .reference(&header)
+            .reference_header(&header)
             .write_nifti(&data)
             .unwrap();
         let (new_header, new_data) = read_as_ndarray::<_, f32, _>(&path);
@@ -275,7 +275,7 @@ mod tests {
         let path = get_temporary_path("error_description.nii");
         let data = Array::from_elem((3, 4, 5), 1.5);
         assert!(WriterOptions::new(&path)
-            .reference(&header)
+            .reference_header(&header)
             .write_nifti(&data)
             .is_err());
     }
@@ -353,7 +353,7 @@ mod tests {
         let data_path = header_path.with_extension("img");
         let header = rgb_header_gt();
         WriterOptions::new(&header_path)
-            .reference(&header)
+            .reference_header(&header)
             .write_rgb_nifti(&data)
             .unwrap();
 
@@ -382,7 +382,7 @@ mod tests {
         let path = get_temporary_path("rgb.nii");
         let header = rgb_header_gt();
         WriterOptions::new(&path)
-            .reference(&header)
+            .reference_header(&header)
             .write_rgb_nifti(&data)
             .unwrap();
 
@@ -407,7 +407,7 @@ mod tests {
         let path = get_temporary_path("rgb.nii");
         let header = rgb_header_gt();
         WriterOptions::new(&path)
-            .reference(&header)
+            .reference_header(&header)
             .write_rgb_nifti(&data)
             .unwrap();
 


### PR DESCRIPTION
Here's a first draft of `WriterOptions`. I don't see anything particularly horrible or insulting to a programmer :) Maybe

- `header_file: bool` is not a super name. Does nifti have a name for the distinct files (nii vs hdr+img)?
- I feel that the path update is "unclean". Maybe we should calculate the final path only in the `write` functions?
- I wanted to add an option to set a reference path, in case the user doesn't want to load the header himself and simply give us the path to the header, but we would lose the [faster] `reference: Option<&'a NiftiHeader>`. If we don't care about copying this struct and we love this feature, I can do it. It would also remove the lifetime, which some people may like :)
- Do you have other ideas of useful parameters?

> This would also be an opportunity to ground one common API for writing, regardless of their data type (RGB) or how they are represented (ndarray or a NiftiVolume type).

I still don't understand how I can write a single function for "normal" **and** rgb image. I see that they now share some common parameters, but we still have the problem with the traits. `[u8; 3]` must respect `DataElement` and `TriviallyTransmutable`. Because of this, I kept the `write_nifti` and `write_rgb_nifti` functions (now transformed to methods).

Fix #49 and maybe some other stuff.