### PR TITLE
Remove public AsPrimitive trait bounds on scalars

### DIFF
--- a/src/typedef.rs
+++ b/src/typedef.rs
@@ -8,7 +8,6 @@ use crate::error::{NiftiError, Result};
 use crate::volume::element::{DataElement, LinearTransform};
 use byteordered::{Endian, Endianness};
 use num_derive::FromPrimitive;
-use num_traits::AsPrimitive;
 use std::io::Read;
 use std::ops::{Add, Mul};
 
@@ -97,22 +96,12 @@ impl NiftiType {
         T: Mul<Output = T>,
         T: Add<Output = T>,
         T: DataElement,
-        u8: AsPrimitive<T>,
-        i8: AsPrimitive<T>,
-        u16: AsPrimitive<T>,
-        i16: AsPrimitive<T>,
-        u32: AsPrimitive<T>,
-        i32: AsPrimitive<T>,
-        u64: AsPrimitive<T>,
-        i64: AsPrimitive<T>,
-        f32: AsPrimitive<T>,
-        f64: AsPrimitive<T>,
     {
         match self {
             NiftiType::Uint8 => {
                 let raw = u8::from_raw(source, endianness)?;
                 Ok(<u8 as DataElement>::Transform::linear_transform(
-                    raw.as_(),
+                    T::from_u8(raw),
                     slope,
                     inter,
                 ))
@@ -120,7 +109,7 @@ impl NiftiType {
             NiftiType::Int8 => {
                 let raw = i8::from_raw(source, endianness)?;
                 Ok(<i8 as DataElement>::Transform::linear_transform(
-                    raw.as_(),
+                    T::from_i8(raw),
                     slope,
                     inter,
                 ))
@@ -128,7 +117,7 @@ impl NiftiType {
             NiftiType::Uint16 => {
                 let raw = endianness.read_u16(source)?;
                 Ok(<u16 as DataElement>::Transform::linear_transform(
-                    raw.as_(),
+                    T::from_u16(raw),
                     slope,
                     inter,
                 ))
@@ -136,7 +125,7 @@ impl NiftiType {
             NiftiType::Int16 => {
                 let raw = endianness.read_i16(source)?;
                 Ok(<i16 as DataElement>::Transform::linear_transform(
-                    raw.as_(),
+                    T::from_i16(raw),
                     slope,
                     inter,
                 ))
@@ -144,7 +133,7 @@ impl NiftiType {
             NiftiType::Uint32 => {
                 let raw = endianness.read_u32(source)?;
                 Ok(<u32 as DataElement>::Transform::linear_transform(
-                    raw.as_(),
+                    T::from_u32(raw),
                     slope,
                     inter,
                 ))
@@ -152,7 +141,7 @@ impl NiftiType {
             NiftiType::Int32 => {
                 let raw = endianness.read_i32(source)?;
                 Ok(<i32 as DataElement>::Transform::linear_transform(
-                    raw.as_(),
+                    T::from_i32(raw),
                     slope,
                     inter,
                 ))
@@ -160,7 +149,7 @@ impl NiftiType {
             NiftiType::Uint64 => {
                 let raw = endianness.read_u64(source)?;
                 Ok(<u64 as DataElement>::Transform::linear_transform(
-                    raw.as_(),
+                    T::from_u64(raw),
                     slope,
                     inter,
                 ))
@@ -168,7 +157,7 @@ impl NiftiType {
             NiftiType::Int64 => {
                 let raw = endianness.read_i64(source)?;
                 Ok(<i64 as DataElement>::Transform::linear_transform(
-                    raw.as_(),
+                    T::from_i64(raw),
                     slope,
                     inter,
                 ))
@@ -176,7 +165,7 @@ impl NiftiType {
             NiftiType::Float32 => {
                 let raw = endianness.read_f32(source)?;
                 Ok(<f32 as DataElement>::Transform::linear_transform(
-                    raw.as_(),
+                    T::from_f32(raw),
                     slope,
                     inter,
                 ))
@@ -184,7 +173,7 @@ impl NiftiType {
             NiftiType::Float64 => {
                 let raw = endianness.read_f64(source)?;
                 Ok(<f64 as DataElement>::Transform::linear_transform(
-                    raw.as_(),
+                    T::from_f64(raw),
                     slope,
                     inter,
                 ))

--- a/src/volume/element.rs
+++ b/src/volume/element.rs
@@ -46,14 +46,13 @@ pub struct LinearTransformViaF32;
 
 impl<T> LinearTransform<T> for LinearTransformViaF32
 where
-    T: AsPrimitive<f32>,
-    f32: AsPrimitive<T>,
+    T: 'static + Copy + DataElement,
 {
     fn linear_transform(value: T, slope: f32, intercept: f32) -> T {
         if slope == 0. {
             return value;
         }
-        (value.as_() * slope + intercept).as_()
+        T::from_f32(AsPrimitive::<f32>::as_(value) * slope + intercept)
     }
 }
 
@@ -65,8 +64,7 @@ pub struct LinearTransformViaF64;
 
 impl<T> LinearTransform<T> for LinearTransformViaF64
 where
-    T: 'static + Copy + AsPrimitive<f64>,
-    f64: AsPrimitive<T>,
+    T: 'static + Copy + DataElement,
 {
     fn linear_transform(value: T, slope: f32, intercept: f32) -> T {
         if slope == 0. {
@@ -74,7 +72,7 @@ where
         }
         let slope: f64 = slope.as_();
         let intercept: f64 = intercept.as_();
-        (value.as_() * slope + intercept).as_()
+        T::from_f64(AsPrimitive::<f64>::as_(value) * slope + intercept)
     }
 }
 
@@ -86,15 +84,14 @@ pub struct LinearTransformViaOriginal;
 
 impl<T> LinearTransform<T> for LinearTransformViaOriginal
 where
-    T: 'static + DataElement + Mul<Output = T> + Add<Output = T> + Copy,
-    f32: AsPrimitive<T>,
+    T: 'static + Copy + DataElement + Mul<Output = T> + Add<Output = T>,
 {
     fn linear_transform(value: T, slope: f32, intercept: f32) -> T {
         if slope == 0. {
             return value;
         }
-        let slope: T = slope.as_();
-        let intercept: T = intercept.as_();
+        let slope = T::from_f32(slope);
+        let intercept = T::from_f32(intercept);
         value * slope + intercept
     }
 }
@@ -116,6 +113,36 @@ pub trait DataElement:
     where
         R: Read,
         E: Endian;
+
+    /// Create a single element by converting a scalar value.
+    fn from_u8(value: u8) -> Self;
+
+    /// Create a single element by converting a scalar value.
+    fn from_i8(value: i8) -> Self;
+
+    /// Create a single element by converting a scalar value.
+    fn from_u16(value: u16) -> Self;
+
+    /// Create a single element by converting a scalar value.
+    fn from_i16(value: i16) -> Self;
+
+    /// Create a single element by converting a scalar value.
+    fn from_u32(value: u32) -> Self;
+
+    /// Create a single element by converting a scalar value.
+    fn from_i32(value: i32) -> Self;
+
+    /// Create a single element by converting a scalar value.
+    fn from_u64(value: u64) -> Self;
+
+    /// Create a single element by converting a scalar value.
+    fn from_i64(value: i64) -> Self;
+
+    /// Create a single element by converting a scalar value.
+    fn from_f32(value: f32) -> Self;
+
+    /// Create a single element by converting a scalar value.
+    fn from_f64(value: f64) -> Self;
 
     /// Transform the given data vector into a vector of data elements.
     fn from_raw_vec<E>(vec: Vec<u8>, endianness: E) -> Result<Vec<Self>>
@@ -147,7 +174,48 @@ impl DataElement for u8 {
     {
         ByteOrdered::native(src).read_u8().map_err(From::from)
     }
+
+    fn from_u8(value: u8) -> Self {
+        value
+    }
+
+    fn from_i8(value: i8) -> Self {
+        value as u8
+    }
+
+    fn from_u16(value: u16) -> Self {
+        value as u8
+    }
+
+    fn from_i16(value: i16) -> Self {
+        value as u8
+    }
+
+    fn from_u32(value: u32) -> Self {
+        value as u8
+    }
+
+    fn from_i32(value: i32) -> Self {
+        value as u8
+    }
+
+    fn from_u64(value: u64) -> Self {
+        value as u8
+    }
+
+    fn from_i64(value: i64) -> Self {
+        value as u8
+    }
+
+    fn from_f32(value: f32) -> Self {
+        value as u8
+    }
+
+    fn from_f64(value: f64) -> Self {
+        value as u8
+    }
 }
+
 impl DataElement for i8 {
     const DATA_TYPE: NiftiType = NiftiType::Int8;
     type Transform = LinearTransformViaF32;
@@ -164,7 +232,48 @@ impl DataElement for i8 {
     {
         ByteOrdered::native(src).read_i8().map_err(From::from)
     }
+
+    fn from_u8(value: u8) -> Self {
+        value as i8
+    }
+
+    fn from_i8(value: i8) -> Self {
+        value
+    }
+
+    fn from_u16(value: u16) -> Self {
+        value as i8
+    }
+
+    fn from_i16(value: i16) -> Self {
+        value as i8
+    }
+
+    fn from_u32(value: u32) -> Self {
+        value as i8
+    }
+
+    fn from_i32(value: i32) -> Self {
+        value as i8
+    }
+
+    fn from_u64(value: u64) -> Self {
+        value as i8
+    }
+
+    fn from_i64(value: i64) -> Self {
+        value as i8
+    }
+
+    fn from_f32(value: f32) -> Self {
+        value as i8
+    }
+
+    fn from_f64(value: f64) -> Self {
+        value as i8
+    }
 }
+
 impl DataElement for u16 {
     const DATA_TYPE: NiftiType = NiftiType::Uint16;
     type Transform = LinearTransformViaF32;
@@ -181,7 +290,48 @@ impl DataElement for u16 {
     {
         e.read_u16(src).map_err(From::from)
     }
+
+    fn from_u8(value: u8) -> Self {
+        value as u16
+    }
+
+    fn from_i8(value: i8) -> Self {
+        value as u16
+    }
+
+    fn from_u16(value: u16) -> Self {
+        value
+    }
+
+    fn from_i16(value: i16) -> Self {
+        value as u16
+    }
+
+    fn from_u32(value: u32) -> Self {
+        value as u16
+    }
+
+    fn from_i32(value: i32) -> Self {
+        value as u16
+    }
+
+    fn from_u64(value: u64) -> Self {
+        value as u16
+    }
+
+    fn from_i64(value: i64) -> Self {
+        value as u16
+    }
+
+    fn from_f32(value: f32) -> Self {
+        value as u16
+    }
+
+    fn from_f64(value: f64) -> Self {
+        value as u16
+    }
 }
+
 impl DataElement for i16 {
     const DATA_TYPE: NiftiType = NiftiType::Int16;
     type Transform = LinearTransformViaF32;
@@ -198,7 +348,48 @@ impl DataElement for i16 {
     {
         e.read_i16(src).map_err(From::from)
     }
+
+    fn from_u8(value: u8) -> Self {
+        value as i16
+    }
+
+    fn from_i8(value: i8) -> Self {
+        value as i16
+    }
+
+    fn from_u16(value: u16) -> Self {
+        value as i16
+    }
+
+    fn from_i16(value: i16) -> Self {
+        value
+    }
+
+    fn from_u32(value: u32) -> Self {
+        value as i16
+    }
+
+    fn from_i32(value: i32) -> Self {
+        value as i16
+    }
+
+    fn from_u64(value: u64) -> Self {
+        value as i16
+    }
+
+    fn from_i64(value: i64) -> Self {
+        value as i16
+    }
+
+    fn from_f32(value: f32) -> Self {
+        value as i16
+    }
+
+    fn from_f64(value: f64) -> Self {
+        value as i16
+    }
 }
+
 impl DataElement for u32 {
     const DATA_TYPE: NiftiType = NiftiType::Uint32;
     type Transform = LinearTransformViaF32;
@@ -214,6 +405,46 @@ impl DataElement for u32 {
         E: Endian,
     {
         e.read_u32(src).map_err(From::from)
+    }
+
+    fn from_u8(value: u8) -> Self {
+        value as u32
+    }
+
+    fn from_i8(value: i8) -> Self {
+        value as u32
+    }
+
+    fn from_u16(value: u16) -> Self {
+        value as u32
+    }
+
+    fn from_i16(value: i16) -> Self {
+        value as u32
+    }
+
+    fn from_u32(value: u32) -> Self {
+        value
+    }
+
+    fn from_i32(value: i32) -> Self {
+        value as u32
+    }
+
+    fn from_u64(value: u64) -> Self {
+        value as u32
+    }
+
+    fn from_i64(value: i64) -> Self {
+        value as u32
+    }
+
+    fn from_f32(value: f32) -> Self {
+        value as u32
+    }
+
+    fn from_f64(value: f64) -> Self {
+        value as u32
     }
 }
 impl DataElement for i32 {
@@ -232,7 +463,48 @@ impl DataElement for i32 {
     {
         e.read_i32(src).map_err(From::from)
     }
+
+    fn from_u8(value: u8) -> Self {
+        value as i32
+    }
+
+    fn from_i8(value: i8) -> Self {
+        value as i32
+    }
+
+    fn from_u16(value: u16) -> Self {
+        value as i32
+    }
+
+    fn from_i16(value: i16) -> Self {
+        value as i32
+    }
+
+    fn from_u32(value: u32) -> Self {
+        value as i32
+    }
+
+    fn from_i32(value: i32) -> Self {
+        value
+    }
+
+    fn from_u64(value: u64) -> Self {
+        value as i32
+    }
+
+    fn from_i64(value: i64) -> Self {
+        value as i32
+    }
+
+    fn from_f32(value: f32) -> Self {
+        value as i32
+    }
+
+    fn from_f64(value: f64) -> Self {
+        value as i32
+    }
 }
+
 impl DataElement for u64 {
     const DATA_TYPE: NiftiType = NiftiType::Uint64;
     type Transform = LinearTransformViaF64;
@@ -249,7 +521,48 @@ impl DataElement for u64 {
     {
         e.read_u64(src).map_err(From::from)
     }
+
+    fn from_u8(value: u8) -> Self {
+        value as u64
+    }
+
+    fn from_i8(value: i8) -> Self {
+        value as u64
+    }
+
+    fn from_u16(value: u16) -> Self {
+        value as u64
+    }
+
+    fn from_i16(value: i16) -> Self {
+        value as u64
+    }
+
+    fn from_u32(value: u32) -> Self {
+        value as u64
+    }
+
+    fn from_i32(value: i32) -> Self {
+        value as u64
+    }
+
+    fn from_u64(value: u64) -> Self {
+        value
+    }
+
+    fn from_i64(value: i64) -> Self {
+        value as u64
+    }
+
+    fn from_f32(value: f32) -> Self {
+        value as u64
+    }
+
+    fn from_f64(value: f64) -> Self {
+        value as u64
+    }
 }
+
 impl DataElement for i64 {
     const DATA_TYPE: NiftiType = NiftiType::Int64;
     type Transform = LinearTransformViaF64;
@@ -265,6 +578,47 @@ impl DataElement for i64 {
         E: Endian,
     {
         e.read_i64(src).map_err(From::from)
+    }
+
+
+    fn from_u8(value: u8) -> Self {
+        value as i64
+    }
+
+    fn from_i8(value: i8) -> Self {
+        value as i64
+    }
+
+    fn from_u16(value: u16) -> Self {
+        value as i64
+    }
+
+    fn from_i16(value: i16) -> Self {
+        value as i64
+    }
+
+    fn from_u32(value: u32) -> Self {
+        value as i64
+    }
+
+    fn from_i32(value: i32) -> Self {
+        value as i64
+    }
+
+    fn from_u64(value: u64) -> Self {
+        value as i64
+    }
+
+    fn from_i64(value: i64) -> Self {
+        value
+    }
+
+    fn from_f32(value: f32) -> Self {
+        value as i64
+    }
+
+    fn from_f64(value: f64) -> Self {
+        value as i64
     }
 }
 impl DataElement for f32 {
@@ -283,6 +637,46 @@ impl DataElement for f32 {
     {
         e.read_f32(src).map_err(From::from)
     }
+
+    fn from_u8(value: u8) -> Self {
+        value as f32
+    }
+
+    fn from_i8(value: i8) -> Self {
+        value as f32
+    }
+
+    fn from_u16(value: u16) -> Self {
+        value as f32
+    }
+
+    fn from_i16(value: i16) -> Self {
+        value as f32
+    }
+
+    fn from_u32(value: u32) -> Self {
+        value as f32
+    }
+
+    fn from_i32(value: i32) -> Self {
+        value as f32
+    }
+
+    fn from_u64(value: u64) -> Self {
+        value as f32
+    }
+
+    fn from_i64(value: i64) -> Self {
+        value as f32
+    }
+
+    fn from_f32(value: f32) -> Self {
+        value
+    }
+
+    fn from_f64(value: f64) -> Self {
+        value as f32
+    }
 }
 impl DataElement for f64 {
     const DATA_TYPE: NiftiType = NiftiType::Float64;
@@ -299,5 +693,45 @@ impl DataElement for f64 {
         E: Endian,
     {
         e.read_f64(src).map_err(From::from)
+    }
+
+    fn from_u8(value: u8) -> Self {
+        value as f64
+    }
+
+    fn from_i8(value: i8) -> Self {
+        value as f64
+    }
+
+    fn from_u16(value: u16) -> Self {
+        value as f64
+    }
+
+    fn from_i16(value: i16) -> Self {
+        value as f64
+    }
+
+    fn from_u32(value: u32) -> Self {
+        value as f64
+    }
+
+    fn from_i32(value: i32) -> Self {
+        value as f64
+    }
+
+    fn from_u64(value: u64) -> Self {
+        value as f64
+    }
+
+    fn from_i64(value: i64) -> Self {
+        value as f64
+    }
+
+    fn from_f32(value: f32) -> Self {
+        value as f64
+    }
+
+    fn from_f64(value: f64) -> Self {
+        value
     }
 }

--- a/src/volume/element.rs
+++ b/src/volume/element.rs
@@ -158,6 +158,51 @@ pub trait DataElement:
     }
 }
 
+/// Mass-implement primitive conversions from scalar types
+macro_rules! fn_from_scalar {
+    ($typ: ty) => {
+        fn from_u8(value: u8) -> Self {
+            value as $typ
+        }
+
+        fn from_i8(value: i8) -> Self {
+            value as $typ
+        }
+
+        fn from_u16(value: u16) -> Self {
+            value as $typ
+        }
+
+        fn from_i16(value: i16) -> Self {
+            value as $typ
+        }
+
+        fn from_u32(value: u32) -> Self {
+            value as $typ
+        }
+
+        fn from_i32(value: i32) -> Self {
+            value as $typ
+        }
+
+        fn from_u64(value: u64) -> Self {
+            value as $typ
+        }
+
+        fn from_i64(value: i64) -> Self {
+            value as $typ
+        }
+
+        fn from_f32(value: f32) -> Self {
+            value as $typ
+        }
+
+        fn from_f64(value: f64) -> Self {
+            value as $typ
+        }
+    };
+}
+
 impl DataElement for u8 {
     const DATA_TYPE: NiftiType = NiftiType::Uint8;
     type Transform = LinearTransformViaF32;
@@ -175,45 +220,7 @@ impl DataElement for u8 {
         ByteOrdered::native(src).read_u8().map_err(From::from)
     }
 
-    fn from_u8(value: u8) -> Self {
-        value
-    }
-
-    fn from_i8(value: i8) -> Self {
-        value as u8
-    }
-
-    fn from_u16(value: u16) -> Self {
-        value as u8
-    }
-
-    fn from_i16(value: i16) -> Self {
-        value as u8
-    }
-
-    fn from_u32(value: u32) -> Self {
-        value as u8
-    }
-
-    fn from_i32(value: i32) -> Self {
-        value as u8
-    }
-
-    fn from_u64(value: u64) -> Self {
-        value as u8
-    }
-
-    fn from_i64(value: i64) -> Self {
-        value as u8
-    }
-
-    fn from_f32(value: f32) -> Self {
-        value as u8
-    }
-
-    fn from_f64(value: f64) -> Self {
-        value as u8
-    }
+    fn_from_scalar!(u8);
 }
 
 impl DataElement for i8 {
@@ -233,45 +240,7 @@ impl DataElement for i8 {
         ByteOrdered::native(src).read_i8().map_err(From::from)
     }
 
-    fn from_u8(value: u8) -> Self {
-        value as i8
-    }
-
-    fn from_i8(value: i8) -> Self {
-        value
-    }
-
-    fn from_u16(value: u16) -> Self {
-        value as i8
-    }
-
-    fn from_i16(value: i16) -> Self {
-        value as i8
-    }
-
-    fn from_u32(value: u32) -> Self {
-        value as i8
-    }
-
-    fn from_i32(value: i32) -> Self {
-        value as i8
-    }
-
-    fn from_u64(value: u64) -> Self {
-        value as i8
-    }
-
-    fn from_i64(value: i64) -> Self {
-        value as i8
-    }
-
-    fn from_f32(value: f32) -> Self {
-        value as i8
-    }
-
-    fn from_f64(value: f64) -> Self {
-        value as i8
-    }
+    fn_from_scalar!(i8);
 }
 
 impl DataElement for u16 {
@@ -291,45 +260,7 @@ impl DataElement for u16 {
         e.read_u16(src).map_err(From::from)
     }
 
-    fn from_u8(value: u8) -> Self {
-        value as u16
-    }
-
-    fn from_i8(value: i8) -> Self {
-        value as u16
-    }
-
-    fn from_u16(value: u16) -> Self {
-        value
-    }
-
-    fn from_i16(value: i16) -> Self {
-        value as u16
-    }
-
-    fn from_u32(value: u32) -> Self {
-        value as u16
-    }
-
-    fn from_i32(value: i32) -> Self {
-        value as u16
-    }
-
-    fn from_u64(value: u64) -> Self {
-        value as u16
-    }
-
-    fn from_i64(value: i64) -> Self {
-        value as u16
-    }
-
-    fn from_f32(value: f32) -> Self {
-        value as u16
-    }
-
-    fn from_f64(value: f64) -> Self {
-        value as u16
-    }
+    fn_from_scalar!(u16);
 }
 
 impl DataElement for i16 {
@@ -349,45 +280,7 @@ impl DataElement for i16 {
         e.read_i16(src).map_err(From::from)
     }
 
-    fn from_u8(value: u8) -> Self {
-        value as i16
-    }
-
-    fn from_i8(value: i8) -> Self {
-        value as i16
-    }
-
-    fn from_u16(value: u16) -> Self {
-        value as i16
-    }
-
-    fn from_i16(value: i16) -> Self {
-        value
-    }
-
-    fn from_u32(value: u32) -> Self {
-        value as i16
-    }
-
-    fn from_i32(value: i32) -> Self {
-        value as i16
-    }
-
-    fn from_u64(value: u64) -> Self {
-        value as i16
-    }
-
-    fn from_i64(value: i64) -> Self {
-        value as i16
-    }
-
-    fn from_f32(value: f32) -> Self {
-        value as i16
-    }
-
-    fn from_f64(value: f64) -> Self {
-        value as i16
-    }
+    fn_from_scalar!(i16);
 }
 
 impl DataElement for u32 {
@@ -407,46 +300,9 @@ impl DataElement for u32 {
         e.read_u32(src).map_err(From::from)
     }
 
-    fn from_u8(value: u8) -> Self {
-        value as u32
-    }
-
-    fn from_i8(value: i8) -> Self {
-        value as u32
-    }
-
-    fn from_u16(value: u16) -> Self {
-        value as u32
-    }
-
-    fn from_i16(value: i16) -> Self {
-        value as u32
-    }
-
-    fn from_u32(value: u32) -> Self {
-        value
-    }
-
-    fn from_i32(value: i32) -> Self {
-        value as u32
-    }
-
-    fn from_u64(value: u64) -> Self {
-        value as u32
-    }
-
-    fn from_i64(value: i64) -> Self {
-        value as u32
-    }
-
-    fn from_f32(value: f32) -> Self {
-        value as u32
-    }
-
-    fn from_f64(value: f64) -> Self {
-        value as u32
-    }
+    fn_from_scalar!(u32);
 }
+
 impl DataElement for i32 {
     const DATA_TYPE: NiftiType = NiftiType::Int32;
     type Transform = LinearTransformViaF32;
@@ -464,45 +320,7 @@ impl DataElement for i32 {
         e.read_i32(src).map_err(From::from)
     }
 
-    fn from_u8(value: u8) -> Self {
-        value as i32
-    }
-
-    fn from_i8(value: i8) -> Self {
-        value as i32
-    }
-
-    fn from_u16(value: u16) -> Self {
-        value as i32
-    }
-
-    fn from_i16(value: i16) -> Self {
-        value as i32
-    }
-
-    fn from_u32(value: u32) -> Self {
-        value as i32
-    }
-
-    fn from_i32(value: i32) -> Self {
-        value
-    }
-
-    fn from_u64(value: u64) -> Self {
-        value as i32
-    }
-
-    fn from_i64(value: i64) -> Self {
-        value as i32
-    }
-
-    fn from_f32(value: f32) -> Self {
-        value as i32
-    }
-
-    fn from_f64(value: f64) -> Self {
-        value as i32
-    }
+    fn_from_scalar!(i32);
 }
 
 impl DataElement for u64 {
@@ -522,45 +340,7 @@ impl DataElement for u64 {
         e.read_u64(src).map_err(From::from)
     }
 
-    fn from_u8(value: u8) -> Self {
-        value as u64
-    }
-
-    fn from_i8(value: i8) -> Self {
-        value as u64
-    }
-
-    fn from_u16(value: u16) -> Self {
-        value as u64
-    }
-
-    fn from_i16(value: i16) -> Self {
-        value as u64
-    }
-
-    fn from_u32(value: u32) -> Self {
-        value as u64
-    }
-
-    fn from_i32(value: i32) -> Self {
-        value as u64
-    }
-
-    fn from_u64(value: u64) -> Self {
-        value
-    }
-
-    fn from_i64(value: i64) -> Self {
-        value as u64
-    }
-
-    fn from_f32(value: f32) -> Self {
-        value as u64
-    }
-
-    fn from_f64(value: f64) -> Self {
-        value as u64
-    }
+    fn_from_scalar!(u64);
 }
 
 impl DataElement for i64 {
@@ -580,47 +360,9 @@ impl DataElement for i64 {
         e.read_i64(src).map_err(From::from)
     }
 
-
-    fn from_u8(value: u8) -> Self {
-        value as i64
-    }
-
-    fn from_i8(value: i8) -> Self {
-        value as i64
-    }
-
-    fn from_u16(value: u16) -> Self {
-        value as i64
-    }
-
-    fn from_i16(value: i16) -> Self {
-        value as i64
-    }
-
-    fn from_u32(value: u32) -> Self {
-        value as i64
-    }
-
-    fn from_i32(value: i32) -> Self {
-        value as i64
-    }
-
-    fn from_u64(value: u64) -> Self {
-        value as i64
-    }
-
-    fn from_i64(value: i64) -> Self {
-        value
-    }
-
-    fn from_f32(value: f32) -> Self {
-        value as i64
-    }
-
-    fn from_f64(value: f64) -> Self {
-        value as i64
-    }
+    fn_from_scalar!(i64);
 }
+
 impl DataElement for f32 {
     const DATA_TYPE: NiftiType = NiftiType::Float32;
     type Transform = LinearTransformViaOriginal;
@@ -638,46 +380,9 @@ impl DataElement for f32 {
         e.read_f32(src).map_err(From::from)
     }
 
-    fn from_u8(value: u8) -> Self {
-        value as f32
-    }
-
-    fn from_i8(value: i8) -> Self {
-        value as f32
-    }
-
-    fn from_u16(value: u16) -> Self {
-        value as f32
-    }
-
-    fn from_i16(value: i16) -> Self {
-        value as f32
-    }
-
-    fn from_u32(value: u32) -> Self {
-        value as f32
-    }
-
-    fn from_i32(value: i32) -> Self {
-        value as f32
-    }
-
-    fn from_u64(value: u64) -> Self {
-        value as f32
-    }
-
-    fn from_i64(value: i64) -> Self {
-        value as f32
-    }
-
-    fn from_f32(value: f32) -> Self {
-        value
-    }
-
-    fn from_f64(value: f64) -> Self {
-        value as f32
-    }
+    fn_from_scalar!(f32);
 }
+
 impl DataElement for f64 {
     const DATA_TYPE: NiftiType = NiftiType::Float64;
     type Transform = LinearTransformViaOriginal;
@@ -695,43 +400,5 @@ impl DataElement for f64 {
         e.read_f64(src).map_err(From::from)
     }
 
-    fn from_u8(value: u8) -> Self {
-        value as f64
-    }
-
-    fn from_i8(value: i8) -> Self {
-        value as f64
-    }
-
-    fn from_u16(value: u16) -> Self {
-        value as f64
-    }
-
-    fn from_i16(value: i16) -> Self {
-        value as f64
-    }
-
-    fn from_u32(value: u32) -> Self {
-        value as f64
-    }
-
-    fn from_i32(value: i32) -> Self {
-        value as f64
-    }
-
-    fn from_u64(value: u64) -> Self {
-        value as f64
-    }
-
-    fn from_i64(value: i64) -> Self {
-        value as f64
-    }
-
-    fn from_f32(value: f32) -> Self {
-        value as f64
-    }
-
-    fn from_f64(value: f64) -> Self {
-        value
-    }
+    fn_from_scalar!(f64);
 }

--- a/src/volume/element.rs
+++ b/src/volume/element.rs
@@ -1,10 +1,10 @@
 //! This module defines the data element API, which enables NIfTI
 //! volume API implementations to read, write and convert data
 //! elements.
-use byteordered::{ByteOrdered, Endian};
-use crate::NiftiType;
 use crate::error::Result;
 use crate::util::convert_bytes_to;
+use crate::NiftiType;
+use byteordered::{ByteOrdered, Endian};
 use num_traits::cast::AsPrimitive;
 use safe_transmute::transmute_vec;
 use std::io::Read;

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -34,11 +34,12 @@ macro_rules! fn_convert_and_cast {
             use crate::volume::element::LinearTransform;
 
             let dim: Vec<_> = self.dim().iter().map(|d| *d as Ix).collect();
-    
+
+            // cast raw data from file) to the corresponding DataElement
             let data: Vec<_> = <$typ as DataElement>::from_raw_vec(self.raw_data, self.endianness)?;
-            let mut data: Vec<O> = data.into_iter()
-                .map($converter)
-                .collect();
+            // cast elements to the requested output type
+            let mut data: Vec<O> = data.into_iter().map($converter).collect();
+            // apply slope and inter before creating the final ndarray
             <O as DataElement>::Transform::linear_transform_many_inline(
                 &mut data,
                 self.scl_slope,

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -35,7 +35,8 @@ macro_rules! fn_convert_and_cast {
 
             let dim: Vec<_> = self.dim().iter().map(|d| *d as Ix).collect();
 
-            // cast raw data from file) to the corresponding DataElement
+            // cast the raw data buffer to the DataElement
+            // corresponding to the declared datatype
             let data: Vec<_> = <$typ as DataElement>::from_raw_vec(self.raw_data, self.endianness)?;
             // cast elements to the requested output type
             let mut data: Vec<O> = data.into_iter().map($converter).collect();

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -10,7 +10,7 @@ use crate::volume::{FromSource, FromSourceOptions, NiftiVolume, RandomAccessNift
 use super::shape::Dim;
 use super::util::coords_to_index;
 use flate2::bufread::GzDecoder;
-use num_traits::{AsPrimitive, Num};
+use num_traits::Num;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::ops::{Add, Mul};
@@ -23,6 +23,32 @@ use super::ndarray::IntoNdArray;
 
 /// The maximum size in bytes to reserve before the volume voxel data is read.
 const PREALLOC_MAX_SIZE: usize = 1 << 28; // 256M
+
+macro_rules! fn_convert_and_cast {
+    ($fname: ident, $typ: ty, $converter: expr) => {
+        #[cfg(feature = "ndarray_volumes")]
+        fn $fname <O> (self) -> Result<Array<O, IxDyn>>
+        where
+            O: DataElement,
+        {
+            use crate::volume::element::LinearTransform;
+
+            let dim: Vec<_> = self.dim().iter().map(|d| *d as Ix).collect();
+    
+            let data: Vec<_> = <$typ as DataElement>::from_raw_vec(self.raw_data, self.endianness)?;
+            let mut data: Vec<O> = data.into_iter()
+                .map($converter)
+                .collect();
+            <O as DataElement>::Transform::linear_transform_many_inline(
+                &mut data,
+                self.scl_slope,
+                self.scl_inter,
+            );
+    
+            Ok(Array::from_shape_vec(IxDyn(&dim).f(), data).expect("Inconsistent raw data size"))
+        }
+    };
+}
 
 /// A data type for a NIFTI-1 volume contained in memory. Objects of this type
 /// contain raw image data, which is converted automatically when using reading
@@ -161,20 +187,6 @@ impl InMemNiftiVolume {
         T: Copy,
         T: Mul<Output = T>,
         T: Add<Output = T>,
-        T: AsPrimitive<u8>,
-        T: AsPrimitive<f32>,
-        T: AsPrimitive<f64>,
-        T: AsPrimitive<u16>,
-        u8: AsPrimitive<T>,
-        i8: AsPrimitive<T>,
-        u16: AsPrimitive<T>,
-        i16: AsPrimitive<T>,
-        u32: AsPrimitive<T>,
-        i32: AsPrimitive<T>,
-        u64: AsPrimitive<T>,
-        i64: AsPrimitive<T>,
-        f32: AsPrimitive<T>,
-        f64: AsPrimitive<T>,
     {
         let index = coords_to_index(coords, self.dim())?;
         let range = &self.raw_data[index * self.datatype.size_of()..];
@@ -182,28 +194,17 @@ impl InMemNiftiVolume {
             .read_primitive_value(range, self.endianness, self.scl_slope, self.scl_inter)
     }
 
-    // Shortcut to avoid repeating the call for all types
-    #[cfg(feature = "ndarray_volumes")]
-    fn convert_bytes_and_cast_to<I, O>(self) -> Result<Array<O, IxDyn>>
-    where
-        I: DataElement,
-        I: AsPrimitive<O>,
-        O: DataElement,
-    {
-        use crate::volume::element::LinearTransform;
 
-        let dim: Vec<_> = self.dim().iter().map(|d| *d as Ix).collect();
-
-        let data: Vec<_> = <I as DataElement>::from_raw_vec(self.raw_data, self.endianness)?;
-        let mut data: Vec<O> = data.into_iter().map(AsPrimitive::as_).collect();
-        <O as DataElement>::Transform::linear_transform_many_inline(
-            &mut data,
-            self.scl_slope,
-            self.scl_inter,
-        );
-
-        Ok(Array::from_shape_vec(IxDyn(&dim).f(), data).expect("Inconsistent raw data size"))
-    }
+    fn_convert_and_cast!(convert_and_cast_u8, u8, DataElement::from_u8);
+    fn_convert_and_cast!(convert_and_cast_i8, i8, DataElement::from_i8);
+    fn_convert_and_cast!(convert_and_cast_u16, u16, DataElement::from_u16);
+    fn_convert_and_cast!(convert_and_cast_i16, i16, DataElement::from_i16);
+    fn_convert_and_cast!(convert_and_cast_u32, u32, DataElement::from_u32);
+    fn_convert_and_cast!(convert_and_cast_i32, i32, DataElement::from_i32);
+    fn_convert_and_cast!(convert_and_cast_u64, u64, DataElement::from_u64);
+    fn_convert_and_cast!(convert_and_cast_i64, i64, DataElement::from_i64);
+    fn_convert_and_cast!(convert_and_cast_f32, f32, DataElement::from_f32);
+    fn_convert_and_cast!(convert_and_cast_f64, f64, DataElement::from_f64);
 }
 
 impl FromSourceOptions for InMemNiftiVolume {
@@ -225,28 +226,18 @@ impl IntoNdArray for InMemNiftiVolume {
     fn into_ndarray<T>(self) -> Result<Array<T, IxDyn>>
     where
         T: DataElement,
-        u8: AsPrimitive<T>,
-        i8: AsPrimitive<T>,
-        u16: AsPrimitive<T>,
-        i16: AsPrimitive<T>,
-        u32: AsPrimitive<T>,
-        i32: AsPrimitive<T>,
-        u64: AsPrimitive<T>,
-        i64: AsPrimitive<T>,
-        f32: AsPrimitive<T>,
-        f64: AsPrimitive<T>,
     {
         match self.datatype {
-            NiftiType::Uint8 => self.convert_bytes_and_cast_to::<u8, T>(),
-            NiftiType::Int8 => self.convert_bytes_and_cast_to::<i8, T>(),
-            NiftiType::Uint16 => self.convert_bytes_and_cast_to::<u16, T>(),
-            NiftiType::Int16 => self.convert_bytes_and_cast_to::<i16, T>(),
-            NiftiType::Uint32 => self.convert_bytes_and_cast_to::<u32, T>(),
-            NiftiType::Int32 => self.convert_bytes_and_cast_to::<i32, T>(),
-            NiftiType::Uint64 => self.convert_bytes_and_cast_to::<u64, T>(),
-            NiftiType::Int64 => self.convert_bytes_and_cast_to::<i64, T>(),
-            NiftiType::Float32 => self.convert_bytes_and_cast_to::<f32, T>(),
-            NiftiType::Float64 => self.convert_bytes_and_cast_to::<f64, T>(),
+            NiftiType::Uint8 => self.convert_and_cast_u8::<T>(),
+            NiftiType::Int8 => self.convert_and_cast_i8::<T>(),
+            NiftiType::Uint16 => self.convert_and_cast_u16::<T>(),
+            NiftiType::Int16 => self.convert_and_cast_i16::<T>(),
+            NiftiType::Uint32 => self.convert_and_cast_u32::<T>(),
+            NiftiType::Int32 => self.convert_and_cast_i32::<T>(),
+            NiftiType::Uint64 => self.convert_and_cast_u64::<T>(),
+            NiftiType::Int64 => self.convert_and_cast_i64::<T>(),
+            NiftiType::Float32 => self.convert_and_cast_f32::<T>(),
+            NiftiType::Float64 => self.convert_and_cast_f64::<T>(),
             //NiftiType::Float128 => {}
             //NiftiType::Complex64 => {}
             //NiftiType::Complex128 => {}
@@ -266,16 +257,6 @@ impl<'a> IntoNdArray for &'a InMemNiftiVolume {
         T: Mul<Output = T>,
         T: Add<Output = T>,
         T: DataElement,
-        u8: AsPrimitive<T>,
-        i8: AsPrimitive<T>,
-        u16: AsPrimitive<T>,
-        i16: AsPrimitive<T>,
-        u32: AsPrimitive<T>,
-        i32: AsPrimitive<T>,
-        u64: AsPrimitive<T>,
-        i64: AsPrimitive<T>,
-        f32: AsPrimitive<T>,
-        f64: AsPrimitive<T>,
     {
         self.clone().into_ndarray()
     }

--- a/src/volume/ndarray.rs
+++ b/src/volume/ndarray.rs
@@ -29,7 +29,6 @@ use crate::error::Result;
 use crate::volume::element::DataElement;
 use crate::volume::NiftiVolume;
 use ndarray::{Array, Axis, Ix, IxDyn};
-use num_traits::AsPrimitive;
 use std::ops::{Add, Mul};
 
 /// Trait for volumes which can be converted to an ndarray.
@@ -43,17 +42,7 @@ pub trait IntoNdArray {
     where
         T: Mul<Output = T>,
         T: Add<Output = T>,
-        T: DataElement,
-        u8: AsPrimitive<T>,
-        i8: AsPrimitive<T>,
-        u16: AsPrimitive<T>,
-        i16: AsPrimitive<T>,
-        u32: AsPrimitive<T>,
-        i32: AsPrimitive<T>,
-        u64: AsPrimitive<T>,
-        i64: AsPrimitive<T>,
-        f32: AsPrimitive<T>,
-        f64: AsPrimitive<T>;
+        T: DataElement;
 }
 
 impl<V> IntoNdArray for super::SliceView<V>
@@ -65,16 +54,6 @@ where
         T: Mul<Output = T>,
         T: Add<Output = T>,
         T: DataElement,
-        u8: AsPrimitive<T>,
-        i8: AsPrimitive<T>,
-        u16: AsPrimitive<T>,
-        i16: AsPrimitive<T>,
-        u32: AsPrimitive<T>,
-        i32: AsPrimitive<T>,
-        u64: AsPrimitive<T>,
-        i64: AsPrimitive<T>,
-        f32: AsPrimitive<T>,
-        f64: AsPrimitive<T>,
     {
         // TODO optimize this implementation (we don't need the whole volume)
         let volume = self.volume.into_ndarray()?;

--- a/tests/volume.rs
+++ b/tests/volume.rs
@@ -52,7 +52,6 @@ mod ndarray_volumes {
         DataElement, InMemNiftiVolume, IntoNdArray, NiftiObject, NiftiType, NiftiVolume,
         ReaderOptions, ReaderStreamedOptions,
     };
-    use num_traits::AsPrimitive;
     use std::fmt;
     use std::ops::{Add, Mul};
 
@@ -262,17 +261,6 @@ mod ndarray_volumes {
         T: Mul<Output = T>,
         T: DataElement,
         T: PartialEq<T>,
-        u8: AsPrimitive<T>,
-        i8: AsPrimitive<T>,
-        u16: AsPrimitive<T>,
-        i16: AsPrimitive<T>,
-        u32: AsPrimitive<T>,
-        i32: AsPrimitive<T>,
-        u64: AsPrimitive<T>,
-        i64: AsPrimitive<T>,
-        f32: AsPrimitive<T>,
-        f64: AsPrimitive<T>,
-        usize: AsPrimitive<T>,
     {
         let volume = ReaderOptions::new()
             .read_file(path)
@@ -282,7 +270,7 @@ mod ndarray_volumes {
 
         let data = volume.into_ndarray::<T>().unwrap();
         for (idx, val) in data.iter().enumerate() {
-            assert_eq!(idx.as_(), *val);
+            assert_eq!(T::from_u64(idx as u64), *val);
         }
     }
 }

--- a/tests/writer.rs
+++ b/tests/writer.rs
@@ -21,7 +21,6 @@ mod tests {
     use ndarray::{
         s, Array, Array1, Array2, Array3, Array4, Array5, Axis, Dimension, Ix2, IxDyn, ShapeBuilder,
     };
-    use num_traits::AsPrimitive;
     use tempfile::tempdir;
 
     use nifti::{
@@ -67,16 +66,6 @@ mod tests {
         T: Add<Output = T>,
         T: DataElement,
         D: Dimension,
-        u8: AsPrimitive<T>,
-        i8: AsPrimitive<T>,
-        u16: AsPrimitive<T>,
-        i16: AsPrimitive<T>,
-        u32: AsPrimitive<T>,
-        i32: AsPrimitive<T>,
-        u64: AsPrimitive<T>,
-        i64: AsPrimitive<T>,
-        f32: AsPrimitive<T>,
-        f64: AsPrimitive<T>,
     {
         let nifti_object = ReaderOptions::new()
             .read_file(path)


### PR DESCRIPTION
Resolves #60.

- Replicate `AsPrimitive` conversion into multiple constructor functions in DataElement
- Rewrite `convert_bytes_and_cast_to` as a macro
   - one for each scalar type
   - reduced trait bounds
- Relax trait bounds on `LinearTransform` impls
- Relax trait bounds on `IntoNdArray` methods
- Relax trait bounds on generic test functions