### PR TITLE
Add ndarray_volumes as a default Cargo feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,13 @@ rust:
 matrix:
   include:
     - rust: stable
-      env: CARGO_FEATURES="--features nalgebra_affine,ndarray_volumes""
+      env: CARGO_FEATURES="--no-default-features"
+    - rust: stable
+      env: CARGO_FEATURES="--features nalgebra_affine,ndarray_volumes"
     - rust: beta
-      env: CARGO_FEATURES="--features nalgebra_affine,ndarray_volumes""
+      env: CARGO_FEATURES="--features nalgebra_affine,ndarray_volumes"
     - rust: nightly
-      env: CARGO_FEATURES="--features nalgebra_affine,ndarray_volumes""
+      env: CARGO_FEATURES="--features nalgebra_affine,ndarray_volumes"
     - rust: stable
       env: CARGO_FEATURES="--features nalgebra_affine,ndarray_volumes"
       os: windows

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,5 +54,6 @@ name = "niftidump"
 path = "examples/niftidump/main.rs"
 
 [features]
+default = ["ndarray_volumes"]
 nalgebra_affine = ["nalgebra", "simba"]
 ndarray_volumes = ["ndarray"]

--- a/README.md
+++ b/README.md
@@ -25,11 +25,17 @@ use nifti::{NiftiObject, InMemNiftiObject};
 let obj = InMemNiftiObject::from_file("myvolume.hdr.gz")?;
 ```
 
-With the `ndarray_volumes` feature enabled, you can also convert a volume to an [`ndarray::Array`](https://docs.rs/ndarray/0.12.0/ndarray/index.html) and work from there:
+With the `ndarray_volumes` feature (enabled by default),
+you can also convert a volume to an [`ndarray::Array`] and work from there:
 
 ```rust
 let volume = obj.into_volume().into_ndarray::<f32>();
 ```
+
+In addition, the `nalgebra_affine` feature unlocks the `affine` module,
+for useful affine transformations.
+
+[`ndarray::Array`]: https://docs.rs/ndarray/0.14.0/ndarray/index.html
 
 ## Roadmap
 


### PR DESCRIPTION
Truth be told, this crate is particularly useful when combined with ndarray,
there are way more use cases which require it than not.
So I say it's time to promote this feature as enabled by default.