### PR TITLE
Create Actions - rust.yml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,56 @@
+on: [push, pull_request]
+
+name: Continuous integration
+
+jobs:
+  # all Cargo feature combinations
+  ci-all:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+         - stable
+        features:
+          - "--no-default-features"
+          - "--features ndarray_volumes,nalgebra_affine"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: ${{ matrix.features }}
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: ${{ matrix.features }}
+
+  # one Cargo feature combination (all)
+  ci-minimal:
+    runs-on:
+     - ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - beta
+        features:
+          - "--features ndarray_volumes,nalgebra_affine"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: ${{ matrix.features }}
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: ${{ matrix.features }}


### PR DESCRIPTION
Now that Travis CI has limited free computational use on public repositories, it's high time one had a transition to GitHub Actions.

While I don't believe that we can achieve an equivalent pipeline at this time, this should suffice for now, and more can be added later.