### PR TITLE
Remove traits for into_ndarray

### DIFF
--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -257,8 +257,6 @@ impl<'a> IntoNdArray for &'a InMemNiftiVolume {
     /// Create an ndarray from the given volume.
     fn into_ndarray<T>(self) -> Result<Array<T, IxDyn>>
     where
-        T: Mul<Output = T>,
-        T: Add<Output = T>,
         T: DataElement,
     {
         self.clone().into_ndarray()

--- a/src/volume/ndarray.rs
+++ b/src/volume/ndarray.rs
@@ -29,7 +29,6 @@ use crate::error::Result;
 use crate::volume::element::DataElement;
 use crate::volume::NiftiVolume;
 use ndarray::{Array, Axis, Ix, IxDyn};
-use std::ops::{Add, Mul};
 
 /// Trait for volumes which can be converted to an ndarray.
 ///
@@ -39,8 +38,6 @@ pub trait IntoNdArray {
     /// and the given target element type `T`.
     fn into_ndarray<T>(self) -> Result<Array<T, IxDyn>>
     where
-        T: Mul<Output = T>,
-        T: Add<Output = T>,
         T: DataElement;
 }
 
@@ -50,8 +47,6 @@ where
 {
     fn into_ndarray<T>(self) -> Result<Array<T, IxDyn>>
     where
-        T: Mul<Output = T>,
-        T: Add<Output = T>,
         T: DataElement,
     {
         // TODO optimize this implementation (we don't need the whole volume)


### PR DESCRIPTION
It seems that `T: Mul<Output = T>,` and `T: Add<Output = T>,` are no longer used for the `into_ndarray` functions.