### PR TITLE
Update libs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ version = "0.24"
 
 [dependencies.ndarray]
 optional = true
-version = "0.14"
+version = "0.15"
 features = ["approx"]
 
 [dependencies.simba]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ optional = true
 version = "0.4"
 
 [dev-dependencies]
-pretty_assertions = "0.6"
+pretty_assertions = "0.7"
 tempfile = "3.1"
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ either = "1.6"
 
 [dependencies.nalgebra]
 optional = true
-version = "0.24"
+version = "0.25"
 
 [dependencies.ndarray]
 optional = true
@@ -43,7 +43,7 @@ features = ["approx"]
 [dependencies.simba]
 default-features = false
 optional = true
-version = "0.3"
+version = "0.4"
 
 [dev-dependencies]
 pretty_assertions = "0.6"


### PR DESCRIPTION
With ndarray ecosystem (npy and stats) ready for 0.15, we might as well update too. I updated `pretty_assertions`, `nalgebra`+`simba` and `ndarray`. There was no specific fix or problem with those libs. And I don't think think we should update the code related to the first three. However, maybe we could update nifti-rs to actually use some of ndarray 0.15 new features, but I don't know this library precisely enough to know where to look. Maybe the best is to wait until we do have a real task and then use what's new.

I didn't update the minimum rust version because it doesn't exist in this library. It's now at Rust 1.49.

As always, if there's nothing in the near-future to change, my colleagues and me would appreciate a release with these changes.