### PR TITLE
Clippy fix + add Clippy to GitHub Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,3 +58,25 @@ jobs:
         with:
           command: test
           args: ${{ matrix.features }}
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+        features:
+          - "--features ndarray_volumes,nalgebra_affine"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: ${{ matrix.features }}

--- a/src/affine.rs
+++ b/src/affine.rs
@@ -127,6 +127,7 @@ pub(crate) fn affine_to_quaternion(affine: &Matrix3<f64>) -> RowVector4<f64> {
 ///
 /// Algorithm from https://en.wikipedia.org/wiki/Rotation_matrix#Quaternion
 #[rustfmt::skip]
+#[allow(clippy::many_single_char_names)]
 pub(crate) fn quaternion_to_affine(q: Quaternion<f64>) -> Matrix3<f64> {
     let nq = q.w * q.w + q.i * q.i + q.j * q.j + q.k * q.k;
     if nq < ::std::f64::EPSILON {

--- a/src/header.rs
+++ b/src/header.rs
@@ -21,9 +21,9 @@ use std::ops::Deref;
 use std::path::Path;
 
 /// Magic code for NIFTI-1 header files (extention ".hdr[.gz]").
-pub const MAGIC_CODE_NI1: &'static [u8; 4] = b"ni1\0";
+pub const MAGIC_CODE_NI1: &[u8; 4] = b"ni1\0";
 /// Magic code for full NIFTI-1 files (extention ".nii[.gz]").
-pub const MAGIC_CODE_NIP1: &'static [u8; 4] = b"n+1\0";
+pub const MAGIC_CODE_NIP1: &[u8; 4] = b"n+1\0";
 
 /// The NIFTI-1 header data type.
 /// All fields are public and named after the specification's header file.
@@ -237,7 +237,7 @@ impl NiftiHeader {
     /// Currently, only the following problems are fixed:
     /// - If `pixdim[0]` isn't equal to -1.0 or 1.0, it will be set to 1.0
     pub fn fix(&mut self) {
-        if self.pixdim[0].abs() != 1.0 {
+        if (self.pixdim[0].abs() - 1.).abs() > 1e-11 {
             self.pixdim[0] = 1.0;
         }
     }
@@ -268,21 +268,21 @@ impl NiftiHeader {
     /// Get the data type as a validated enum.
     pub fn data_type(&self) -> Result<NiftiType> {
         FromPrimitive::from_i16(self.datatype)
-            .ok_or_else(|| NiftiError::InvalidCode("datatype", self.datatype))
+            .ok_or(NiftiError::InvalidCode("datatype", self.datatype))
     }
 
     /// Get the spatial units type as a validated unit enum.
     pub fn xyzt_to_space(&self) -> Result<Unit> {
         let space_code = self.xyzt_units & 0o0007;
         FromPrimitive::from_u8(space_code)
-            .ok_or_else(|| NiftiError::InvalidCode("xyzt units (space)", space_code as i16))
+            .ok_or(NiftiError::InvalidCode("xyzt units (space)", space_code as i16))
     }
 
     /// Get the time units type as a validated unit enum.
     pub fn xyzt_to_time(&self) -> Result<Unit> {
         let time_code = self.xyzt_units & 0o0070;
         FromPrimitive::from_u8(time_code)
-            .ok_or_else(|| NiftiError::InvalidCode("xyzt units (time)", time_code as i16))
+            .ok_or(NiftiError::InvalidCode("xyzt units (time)", time_code as i16))
     }
 
     /// Get the xyzt units type as a validated pair of space and time unit enum.
@@ -293,25 +293,25 @@ impl NiftiHeader {
     /// Get the slice order as a validated enum.
     pub fn slice_order(&self) -> Result<SliceOrder> {
         FromPrimitive::from_u8(self.slice_code)
-            .ok_or_else(|| NiftiError::InvalidCode("slice order", self.slice_code as i16))
+            .ok_or(NiftiError::InvalidCode("slice order", self.slice_code as i16))
     }
 
     /// Get the intent as a validated enum.
     pub fn intent(&self) -> Result<Intent> {
         FromPrimitive::from_i16(self.intent_code)
-            .ok_or_else(|| NiftiError::InvalidCode("intent", self.intent_code))
+            .ok_or(NiftiError::InvalidCode("intent", self.intent_code))
     }
 
     /// Get the qform coordinate mapping method as a validated enum.
     pub fn qform(&self) -> Result<XForm> {
         FromPrimitive::from_i16(self.qform_code)
-            .ok_or_else(|| NiftiError::InvalidCode("qform", self.qform_code as i16))
+            .ok_or(NiftiError::InvalidCode("qform", self.qform_code as i16))
     }
 
     /// Get the sform coordinate mapping method as a validated enum.
     pub fn sform(&self) -> Result<XForm> {
         FromPrimitive::from_i16(self.sform_code)
-            .ok_or_else(|| NiftiError::InvalidCode("sform", self.sform_code as i16))
+            .ok_or(NiftiError::InvalidCode("sform", self.sform_code as i16))
     }
 
     /// Ensure that the current `descrip` field is valid and is exactly equal to 80 bytes.
@@ -336,16 +336,18 @@ impl NiftiHeader {
         D: Deref<Target = [u8]>,
     {
         let len = description.len();
-        if len < 80 {
-            let mut descrip = vec![0; 80];
-            descrip[..len].copy_from_slice(&description);
-            self.descrip = descrip;
-            Ok(())
-        } else if len == 80 {
-            self.descrip = description.into();
-            Ok(())
-        } else {
-            Err(NiftiError::IncorrectDescriptionLength(len))
+        match len.cmp(&80) {
+            std::cmp::Ordering::Less => {
+                let mut descrip = vec![0; 80];
+                descrip[..len].copy_from_slice(&description);
+                self.descrip = descrip;
+                Ok(())
+            }
+            std::cmp::Ordering::Equal => {
+                self.descrip = description.into();
+                Ok(())
+            }
+            _ => Err(NiftiError::IncorrectDescriptionLength(len)),
         }
     }
 
@@ -406,7 +408,7 @@ impl NiftiHeader {
         if self.pixdim[1] < 0.0 || self.pixdim[2] < 0.0 || self.pixdim[3] < 0.0 {
             panic!("All spacings (pixdim) should be positive");
         }
-        if self.pixdim[0].abs() != 1.0 {
+        if (self.pixdim[0].abs() - 1.).abs() > 1e-11 {
             panic!("qfac (pixdim[0]) should be 1 or -1");
         }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -237,7 +237,7 @@ impl NiftiHeader {
     /// Currently, only the following problems are fixed:
     /// - If `pixdim[0]` isn't equal to -1.0 or 1.0, it will be set to 1.0
     pub fn fix(&mut self) {
-        if (self.pixdim[0].abs() - 1.).abs() > 1e-11 {
+        if !self.is_pixdim_0_valid() {
             self.pixdim[0] = 1.0;
         }
     }
@@ -358,6 +358,12 @@ impl NiftiHeader {
     {
         self.set_description(description.into().as_bytes())
     }
+
+    /// Check whether `pixdim[0]` is either -1 or 1.
+    #[inline]
+    fn is_pixdim_0_valid(&self) -> bool {
+        (self.pixdim[0].abs() - 1.).abs() < 1e-11
+    }
 }
 
 #[cfg(feature = "nalgebra_affine")]
@@ -408,7 +414,7 @@ impl NiftiHeader {
         if self.pixdim[1] < 0.0 || self.pixdim[2] < 0.0 || self.pixdim[3] < 0.0 {
             panic!("All spacings (pixdim) should be positive");
         }
-        if (self.pixdim[0].abs() - 1.).abs() > 1e-11 {
+        if !self.is_pixdim_0_valid() {
             panic!("qfac (pixdim[0]) should be 1 or -1");
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@
 //!
 #![deny(missing_debug_implementations)]
 #![warn(missing_docs, unused_extern_crates, trivial_casts, unused_results)]
+#![allow(clippy::unit_arg)]
 #![recursion_limit = "128"]
 
 #[cfg(all(test, feature = "nalgebra_affine"))]

--- a/src/object.rs
+++ b/src/object.rs
@@ -24,12 +24,18 @@ pub struct ReaderOptions {
     fix_header: bool,
 }
 
+impl Default for ReaderOptions {
+    fn default() -> Self {
+        ReaderOptions { fix_header: false }
+    }
+}
+
 impl ReaderOptions {
     /// Creates a blank new set of options ready for configuration.
     ///
     /// All options are initially set to `false`.
-    pub fn new() -> ReaderOptions {
-        ReaderOptions { fix_header: false }
+    pub fn new() -> Self {
+        Default::default()
     }
 
     /// Sets the options to fix some known header problems.
@@ -100,12 +106,18 @@ pub struct ReaderStreamedOptions {
     fix_header: bool,
 }
 
+impl Default for ReaderStreamedOptions {
+    fn default() -> Self {
+        ReaderStreamedOptions { fix_header: false }
+    }
+}
+
 impl ReaderStreamedOptions {
     /// Creates a blank new set of options ready for configuration.
     ///
     /// All options are initially set to `false`.
-    pub fn new() -> ReaderStreamedOptions {
-        ReaderStreamedOptions { fix_header: false }
+    pub fn new() -> Self {
+        Default::default()
     }
 
     /// Sets the options to fix some known header problems.

--- a/src/volume/shape.rs
+++ b/src/volume/shape.rs
@@ -61,7 +61,7 @@ impl Idx {
     /// # Ok::<(), nifti::NiftiError>(())
     /// ```
     pub fn from_slice(idx: &[u16]) -> Result<Self> {
-        if idx.len() == 0 || idx.len() > 7 {
+        if idx.is_empty() || idx.len() > 7 {
             return Err(NiftiError::InconsistentDim(0, idx.len() as u16));
         }
         let mut raw = [0; 8];
@@ -143,7 +143,7 @@ impl Dim {
     where
         T: 'static + Copy + AsPrimitive<u16>,
     {
-        if dim.len() == 0 || dim.len() > 7 {
+        if dim.is_empty() || dim.len() > 7 {
             return Err(NiftiError::InconsistentDim(0, dim.len() as u16));
         }
         let mut raw = [1; 8];

--- a/src/volume/streamed.rs
+++ b/src/volume/streamed.rs
@@ -220,7 +220,7 @@ where
     /// }
     /// # Ok::<(), nifti::NiftiError>(())
     /// ```
-    pub fn indexed<'a>(&'a mut self) -> impl Iterator<Item = Result<(Idx, InMemNiftiVolume)>> + 'a {
+    pub fn indexed(&mut self) -> impl Iterator<Item = Result<(Idx, InMemNiftiVolume)>> + '_ {
         let (_, r) = self.dim.split(self.slice_dim.rank() as u16);
         self.zip(r.index_iter())
             .map(|(vol_result, idx)| vol_result.map(|v| (idx, v)))

--- a/src/volume/util.rs
+++ b/src/volume/util.rs
@@ -24,7 +24,7 @@ pub fn coords_to_index(coords: &[u16], dim: &[u16]) -> Result<usize> {
         return Err(NiftiError::OutOfBounds(Vec::from(coords)));
     }
 
-    let mut crds = coords.into_iter();
+    let mut crds = coords.iter();
     let start = *crds.next_back().unwrap() as usize;
     let index = crds
         .zip(dim)

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -27,12 +27,13 @@ enum HeaderReference<'a> {
 impl<'a> HeaderReference<'a> {
     fn to_header(&self) -> Result<NiftiHeader> {
         match self {
-            HeaderReference::FromHeader(h) => Ok(h.clone().to_owned()),
+            HeaderReference::FromHeader(h) => Ok((*h).to_owned()),
             HeaderReference::FromFile(path) => NiftiHeader::from_file(path),
             HeaderReference::None => {
-                let mut header = NiftiHeader::default();
-                header.sform_code = 2;
-                Ok(header)
+                Ok(NiftiHeader {
+                    sform_code: 2,
+                    .. NiftiHeader::default()
+                })
             }
         }
     }


### PR DESCRIPTION
The cool thing about having an action for Clippy here is that detected problems are presented inline with the code changes.

The greatest change was taking the recommendation not to make exact comparisons in floating point types.
This was being done in header correction for `pixdim[0]`, to check whether it is either 1 or -1.