### PR TITLE
Support NIFTI-2, resolves #89

### DIFF
--- a/src/affine.rs
+++ b/src/affine.rs
@@ -23,7 +23,7 @@ where
 ///
 /// We get the translations from the center of the image (implied by `shape`).
 #[rustfmt::skip]
-pub(crate) fn shape_zoom_affine(shape: &[u16], spacing: &[f32]) -> Matrix4<f64> {
+pub(crate) fn shape_zoom_affine(shape: &[u64], spacing: &[f64]) -> Matrix4<f64> {
     // Get translations from center of image
     let origin = Vector3::new(
         (shape[0] as f64 - 1.0) / 2.0,

--- a/src/error.rs
+++ b/src/error.rs
@@ -72,6 +72,16 @@ quick_error! {
         InvalidCode(typename: &'static str, code: i16) {
             display("invalid code `{}` for header field {}", code, typename)
         }
+        /// Integer field size is not large enough to hold assigned value
+        FieldSize(err: std::num::TryFromIntError) {
+            from()
+            source(err)
+        }
+        /// Invalid header size.  Header size must be 540 for NIfTI-2 or 348 for
+        /// NIfTI-1.
+        InvalidHeaderSize(sizeof_hdr: i32) {
+            display("Invalid header size {} must eb 540 for NIfTI-2 or 348 for NIfTI-1.", sizeof_hdr)
+        }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,14 +16,14 @@ quick_error! {
         /// The field `dim` is in an invalid state, as a consequence of
         /// `dim[0]` or one of the elements in `1..dim[0] + 1` not being
         /// positive.
-        InconsistentDim(index: u8, value: u16) {
+        InconsistentDim(index: u8, value: u64) {
             display("Inconsistent value `{}` in header field dim[{}] ({})", value, index, match index {
                 0 if *value > 7 => "must not be higher than 7",
                 _ => "must be positive"
             })
         }
         /// Attempted to read volume outside boundaries.
-        OutOfBounds(coords: Vec<u16>) {
+        OutOfBounds(coords: Vec<u64>) {
             display("Out of bounds access to volume: {:?}", &coords[..])
         }
         /// Attempted to read a volume over a volume's unexistent dimension.
@@ -69,7 +69,7 @@ quick_error! {
             display("Description length ({} bytes) is greater than 80 bytes.", len)
         }
         /// Header contains a code which is not valid for the given attribute
-        InvalidCode(typename: &'static str, code: i16) {
+        InvalidCode(typename: &'static str, code: i32) {
             display("invalid code `{}` for header field {}", code, typename)
         }
         /// Integer field size is not large enough to hold assigned value

--- a/src/header.rs
+++ b/src/header.rs
@@ -206,7 +206,7 @@ impl Default for NiftiHeader {
 
             intent_name: [0; 16],
 
-            magic: *MAGIC_CODE_NI1,
+            magic: *MAGIC_CODE_NIP1,
 
             endianness: Endianness::native(),
         }

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,5 +1,5 @@
 //! This module defines the `NiftiHeader` struct, which is used
-//! to provide important information about NIFTI-1 volumes.
+//! to provide important information about NIFTI volumes.
 
 #[cfg(feature = "nalgebra_affine")]
 use crate::affine::*;
@@ -15,6 +15,7 @@ use num_traits::FromPrimitive;
 use num_traits::ToPrimitive;
 #[cfg(feature = "nalgebra_affine")]
 use simba::scalar::SubsetOf;
+use std::convert::TryInto;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::ops::Deref;
@@ -29,24 +30,202 @@ pub const MAGIC_CODE_NI2: &[u8; 8] = b"ni2\0\r\n\x1A\n";
 /// Magic code for full NIFTI-1 files (extention ".nii[.gz]").
 pub const MAGIC_CODE_NIP2: &[u8; 8] = b"n+2\0\r\n\x1A\n";
 
-/// The NIFTI-1 header data type.
-/// All fields are public and named after the specification's header file.
-/// The type of each field was adjusted according to their use and
-/// array limitations.
-///
+/// Abstraction over NIFTI version 1 and 2 headers.  This is the high-level type
+/// you will likely use most often.
+/// 
+/// The NIFTI file format has two different versions for headers.  NIFTI-1 was
+/// finalized in 2007 and is still widely used by many scanner manufacturers.
+/// NIFTI-2 was created in 2011 and is widely used in many research-oriented
+/// neuroimaging data sets.  NIFTI-2 is almost identical to NIFTI-1 except for
+/// using larger data types (e.g. 64-bit floating point types instead of 32-bit)
+/// and removal of some unused fields.  Refer to the
+/// [reference documentation](https://nifti.nimh.nih.gov/pub/dist/doc/nifti2.h)
+/// for a comprehensive list of changes.
+/// 
+/// For practical purposes, there is no difference between the header versions.
+/// This `NiftiHeader` type is an `enum` storing either a `Nifti2Header` or
+/// `Nifti1Header`.  Calling `from_file()` or `from_reader()` automatically
+/// selects the correct variant depending on the version in the input file.
+/// Getter and setter methods like `get_slice_duration()` and
+/// `set_slice_duration()`, and high-level methods like `data_type()`,
+/// automatically convert values to/from the appropriate underlying type
+/// depending on the header version.
+/// 
+/// If you must work with a specific header version, you can easily convert
+/// between versions with `into_nifti1()` or `into_nifti2()`.
+/// 
 /// # Examples
 ///
 /// ```no_run
-/// use nifti::{NiftiHeader, Endianness};
+/// use nifti::{NiftiHeader, NiftiType};
 /// # use nifti::Result;
 ///
 /// # fn run() -> Result<()> {
+/// // Read a header from a file.
 /// let hdr1 = NiftiHeader::from_file("0000.hdr")?;
 /// let hdr2 = NiftiHeader::from_file("0001.hdr.gz")?;
 /// let hdr3 = NiftiHeader::from_file("4321.nii.gz")?;
+/// 
+/// // Convert a header into NIFTI-2 (does nothing if already NIFTI-2).
+/// // First extracts/converts the `NiftiHeader` into a `Nifti2Header` and then
+/// // puts it back into a `NiftiHeader`.
+/// let hdr4 = hdr3.into_nifti2().into_nifti();
+/// 
+/// // Make a new header from scratch.  Defaults to NIFTI-2.
+/// let mut hdr5 = NiftiHeader::default();
+/// 
+/// // Change the slice duration to two-and-a-half seconds.
+/// hdr5.set_slice_duration(2.5);
+/// assert_eq!(hdr1.get_slice_duration(), 2.5);
 /// # Ok(())
 /// # }
 /// ```
+#[derive(Debug, Clone, PartialEq)]
+pub enum NiftiHeader {
+    /// The underlying header version is `NIFTI-1`.
+    Nifti1Header(Nifti1Header),
+    /// The underlying header version is `NIFTI-2`.
+    Nifti2Header(Nifti2Header),
+}
+impl Default for NiftiHeader {
+    fn default() -> NiftiHeader {
+        Nifti2Header::default().into_nifti() // default to NIfTI-2 format
+    }
+}
+impl NiftiHeader {
+    /// Convert this header into a NIFTI-2 header.
+    /// Does nothing if the header is already NIFTI-2.
+    /// Promotes NIFTI-1 fields to larger types and removes unused fields.
+    /// Increases header size from NIFTI-1's 348 to NIFTI-2's 540 bytes.
+    /// Moves vox_offset forward by corresponding 192 bytes.
+    /// Changes NIFTI-1 magic string to NIFTI-2 magic string.
+    pub fn into_nifti2(self) -> Nifti2Header {
+        match self {
+            Self::Nifti1Header(header) => {
+                Nifti2Header {
+                    // If the original header file uses the NIFTI-1 magic string
+                    // for .hdr/.img then the new header should use the NIFTI-2
+                    // magic string for this filetype, otherwise use the magic
+                    // string for .nii.
+                    magic: if &header.magic == MAGIC_CODE_NI1 {
+                        *MAGIC_CODE_NI2
+                    } else {
+                        *MAGIC_CODE_NIP2
+                    },
+                    datatype: header.datatype,
+                    bitpix: header.bitpix,
+                    dim: header.dim.map(|x| x as u64),
+                    intent_p1: header.intent_p1 as f64,
+                    intent_p2: header.intent_p2 as f64,
+                    intent_p3: header.intent_p3 as f64,
+                    pixdim: header.pixdim.map(|x| x as f64),
+                    // Voxel offset should be equal to previous voxel offset
+                    // plus difference in header size = 540 - 348 = 192.
+                    vox_offset: header.vox_offset.round() as u64 + 192,
+                    scl_slope: header.scl_slope as f64,
+                    scl_inter: header.scl_inter as f64,
+                    cal_max: header.cal_max as f64,
+                    cal_min: header.cal_min as f64,
+                    slice_duration: header.slice_duration as f64,
+                    toffset: header.toffset as f64,
+                    slice_start: header.slice_start as u64,
+                    slice_end: header.slice_end as u64,
+                    descrip: header.descrip,
+                    aux_file: header.aux_file,
+                    qform_code: header.qform_code as i32,
+                    sform_code: header.sform_code as i32,
+                    quatern_b: header.quatern_b as f64,
+                    quatern_c: header.quatern_c as f64,
+                    quatern_d: header.quatern_d as f64,
+                    quatern_x: header.quatern_x as f64,
+                    quatern_y: header.quatern_y as f64,
+                    quatern_z: header.quatern_z as f64,
+                    srow_x: header.srow_x.map(|x| x as f64),
+                    srow_y: header.srow_y.map(|x| x as f64),
+                    srow_z: header.srow_z.map(|x| x as f64),
+                    slice_code: header.slice_code as i32,
+                    xyzt_units: header.xyzt_units as i32,
+                    intent_code: header.intent_code as i32,
+                    intent_name: header.intent_name,
+                    dim_info: header.dim_info,
+                    endianness: header.endianness,
+                    ..Default::default()
+                }
+            },
+            Self::Nifti2Header(header) => header,
+        }
+    }
+
+    /// Convert this header into a NIFTI-1 header.
+    /// Does nothing if the header is already NIFTI-1.
+    /// Shrinks the NIFTI-2 header size from 540 to NIFTI-1's 348, and moves
+    /// vox_offset back by a corresponding 192 bytes.
+    /// Attempts to downcast NIFTI-2 fields to their smaller NIFTI-1 types.
+    /// Performs saturating downcast for floating point fields.
+    /// Performs fallible downcast for integer fields, returning
+    /// [`NiftiError::FieldSize`] if the field won't fit into the smaller type.
+    /// Initializes the unused data_type, db_name, extents, session_error,
+    /// regular, glmax, and glmin fields with their default (zero) values.
+    pub fn into_nifti1(self) -> Result<Nifti1Header> {
+        Ok( match self {
+            Self::Nifti1Header(header) => header,
+            Self::Nifti2Header(header) => {
+                Nifti1Header {
+                    dim_info: header.dim_info,
+                    dim: { // attempt to map u64 to u16 that fits in an i16
+                        let mut dim: [u16; 8] = [0; 8];
+                        for (&src, dst) in header.dim.iter().zip(&mut dim) {
+                            *dst = TryInto::<i16>::try_into(src)? as u16;
+                        }
+                        dim
+                    },
+                    intent_p1: header.intent_p1 as f32,
+                    intent_p2: header.intent_p2 as f32,
+                    intent_p3: header.intent_p3 as f32,
+                    intent_code: header.intent_code.try_into()?,
+                    datatype: header.datatype,
+                    bitpix: header.bitpix,
+                    slice_start: TryInto::<i16>::try_into(header.slice_start)? as u16,
+                    pixdim: header.pixdim.map(|x| x as f32),
+                    vox_offset: TryInto::<i32>::try_into(header.vox_offset)? as f32,
+                    scl_slope: header.scl_slope as f32,
+                    scl_inter: header.scl_inter as f32,
+                    slice_end: TryInto::<i16>::try_into(header.slice_end)? as u16,
+                    slice_code: header.slice_code.try_into()?,
+                    xyzt_units: header.xyzt_units.try_into()?,
+                    cal_max: header.cal_max as f32,
+                    cal_min: header.cal_min as f32,
+                    slice_duration: header.slice_duration as f32,
+                    toffset: header.toffset as f32,
+                    descrip: header.descrip,
+                    aux_file: header.aux_file,
+                    qform_code: header.qform_code.try_into()?,
+                    sform_code: header.sform_code.try_into()?,
+                    quatern_b: header.quatern_b as f32,
+                    quatern_c: header.quatern_c as f32,
+                    quatern_d: header.quatern_d as f32,
+                    quatern_x: header.quatern_x as f32,
+                    quatern_y: header.quatern_y as f32,
+                    quatern_z: header.quatern_z as f32,
+                    srow_x: header.srow_x.map(|x| x as f32),
+                    srow_y: header.srow_y.map(|x| x as f32),
+                    srow_z: header.srow_z.map(|x| x as f32),
+                    intent_name: header.intent_name,
+                    // If the original header file uses the NIFTI-1 magic string
+                    // for .hdr/.img then the new header should use the NIFTI-2
+                    // magic string for this filetype, otherwise use the magic
+                    // string for .nii.
+                    magic: if &header.magic == MAGIC_CODE_NI2 {
+                        *MAGIC_CODE_NI1
+                    } else {
+                        *MAGIC_CODE_NIP1
+                    },
+                    endianness: header.endianness,
+                    ..Default::default()
+                }
+            },
+        } )
+    }
 /// The NIFTI-1 header data type.
 /// 
 /// All fields are public and named after the specification's header file.
@@ -379,22 +558,17 @@ impl Default for Nifti2Header {
     }
 }
 
-    /// Retrieve and validate the number of dimensions of the volume. This is
-    /// `dim[0]` after the necessary byte order conversions.
-    ///
-    /// # Error
-    ///
-    /// `NiftiError::` if `dim[0]` does not represent a valid dimensionality
-    /// (it must be positive and not higher than 7).
-    pub fn dimensionality(&self) -> Result<usize> {
-        validate_dimensionality(&self.dim)
+impl Nifti1Header {
+    /// Place this `Nifti1Header` into a version-agnostic [`NiftiHeader`] enum.
+    pub fn into_nifti(self) -> NiftiHeader {
+        NiftiHeader::Nifti1Header(self)
     }
 }
 
-    /// Check whether `pixdim[0]` is either -1 or 1.
-    #[inline]
-    fn is_pixdim_0_valid(&self) -> bool {
-        (self.pixdim[0].abs() - 1.).abs() < 1e-11
+impl Nifti2Header {
+    /// Place this `Nifti2Header` into a version-agnostic [`NiftiHeader`] enum.
+    pub fn into_nifti(self) -> NiftiHeader {
+        NiftiHeader::Nifti2Header(self)
     }
 }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -1001,9 +1001,9 @@ impl NiftiHeader {
     /// - If `pixdim[0]` isn't equal to -1.0 or 1.0, it will be set to 1.0
     pub fn fix(&mut self) {
         let mut pixdim = self.get_pixdim();
-        if !Self::is_pixdim_0_valid(pixdim[0]) {
+        if !self.is_pixdim_0_valid() {
             pixdim[0] = 1.;
-            self.set_pixdim(pixdim);
+            self.set_pixdim(&pixdim);
         }
     }
 
@@ -1113,8 +1113,8 @@ impl NiftiHeader {
 
     /// Check whether `pixdim[0]` is either -1 or 1.
     #[inline]
-    fn is_pixdim_0_valid(pixdim0: f64) -> bool {
-        (pixdim0.abs() - 1.).abs() < 1e-11
+    fn is_pixdim_0_valid(&self) -> bool {
+        (self.get_pixdim()[0].abs() - 1.).abs() < 1e-11
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ pub mod writer;
 pub use byteordered::Endianness;
 pub use error::{NiftiError, Result};
 pub use extension::{Extender, Extension, ExtensionSequence};
-pub use header::NiftiHeader;
+pub use header::{NiftiHeader, Nifti1Header, Nifti2Header};
 pub use object::{
     InMemNiftiObject, NiftiObject, ReaderOptions, ReaderStreamedOptions, StreamedNiftiObject,
 };

--- a/src/object.rs
+++ b/src/object.rs
@@ -505,7 +505,7 @@ impl<V> GenericNiftiObject<V> {
         let len = if len < 352 { 0 } else { len - 352 };
 
         let ext = {
-            let source = ByteOrdered::runtime(&mut source, header.endianness);
+            let source = ByteOrdered::runtime(&mut source, header.get_endianness());
             ExtensionSequence::from_reader(extender, source, len)?
         };
 
@@ -563,7 +563,7 @@ impl<V> GenericNiftiObject<V> {
             let len = if len < 352 { 0 } else { len - 352 };
 
             let ext = {
-                let stream = ByteOrdered::runtime(&mut stream, header.endianness);
+                let stream = ByteOrdered::runtime(&mut stream, header.get_endianness());
                 ExtensionSequence::from_reader(extender, stream, len)?
             };
 

--- a/src/typedef.rs
+++ b/src/typedef.rs
@@ -88,8 +88,8 @@ impl NiftiType {
         self,
         source: S,
         endianness: Endianness,
-        slope: f32,
-        inter: f32,
+        slope: f64,
+        inter: f64,
     ) -> Result<T>
     where
         S: Read,

--- a/src/util.rs
+++ b/src/util.rs
@@ -101,7 +101,7 @@ pub fn validate_dimensionality(raw_dim: &[u16; 8]) -> Result<usize> {
 pub fn nb_bytes_for_data(header: &NiftiHeader) -> Result<usize> {
     let resolution = nb_values_for_dims(header.dim()?);
     resolution
-        .and_then(|r| r.checked_mul(header.bitpix as usize / 8))
+        .and_then(|r| r.checked_mul(usize::from(header.get_bitpix()) / 8))
         .ok_or(NiftiError::BadVolumeSize)
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,6 +8,7 @@ use either::Either;
 use flate2::bufread::GzDecoder;
 use safe_transmute::{transmute_vec, TriviallyTransmutable};
 use std::borrow::Cow;
+use std::convert::TryInto;
 use std::fs::File;
 use std::io::{BufReader, Read, Result as IoResult, Seek};
 use std::mem;
@@ -76,7 +77,7 @@ where
 ///
 /// Errors if `dim[0]` is outside the accepted rank boundaries or
 /// one of the used dimensions is not positive.
-pub fn validate_dim(raw_dim: &[u16; 8]) -> Result<&[u16]> {
+pub fn validate_dim(raw_dim: &[u64; 8]) -> Result<&[u64]> {
     let ndim = validate_dimensionality(raw_dim)?;
     let o = &raw_dim[1..=ndim];
     if let Some(i) = o.iter().position(|&x| x == 0) {
@@ -91,28 +92,28 @@ pub fn validate_dim(raw_dim: &[u16; 8]) -> Result<&[u16]> {
 ///
 /// Errors if `raw_dim[0]` is outside the accepted rank boundaries: 0 or
 /// larger than 7.
-pub fn validate_dimensionality(raw_dim: &[u16; 8]) -> Result<usize> {
+pub fn validate_dimensionality(raw_dim: &[u64; 8]) -> Result<usize> {
     if raw_dim[0] == 0 || raw_dim[0] > 7 {
         return Err(NiftiError::InconsistentDim(0, raw_dim[0]));
     }
-    Ok(usize::from(raw_dim[0]))
+    Ok(raw_dim[0].try_into()?)
 }
 
 pub fn nb_bytes_for_data(header: &NiftiHeader) -> Result<usize> {
-    let resolution = nb_values_for_dims(header.dim()?);
+    let resolution = nb_values_for_dims(&header.dim()?);
     resolution
         .and_then(|r| r.checked_mul(usize::from(header.get_bitpix()) / 8))
         .ok_or(NiftiError::BadVolumeSize)
 }
 
-pub fn nb_values_for_dims(dim: &[u16]) -> Option<usize> {
+pub fn nb_values_for_dims(dim: &[u64]) -> Option<usize> {
     dim.iter()
         .cloned()
-        .map(usize::from)
-        .fold(Some(1), |acc, v| acc.and_then(|x| x.checked_mul(v)))
+        .map(TryInto::<usize>::try_into)
+        .fold(Some(1), |acc, v| acc.and_then(|x| v.map_or(None, |v| x.checked_mul(v))))
 }
 
-pub fn nb_bytes_for_dim_datatype(dim: &[u16], datatype: NiftiType) -> Option<usize> {
+pub fn nb_bytes_for_dim_datatype(dim: &[u64], datatype: NiftiType) -> Option<usize> {
     let resolution = nb_values_for_dims(dim);
     resolution.and_then(|r| r.checked_mul(datatype.size_of()))
 }

--- a/src/volume/element.rs
+++ b/src/volume/element.rs
@@ -19,11 +19,11 @@ use std::ops::{Add, Mul};
 /// intercept arguments to `f64`.
 pub trait LinearTransform<T: 'static + Copy> {
     /// Linearly transform a value with the given slope and intercept.
-    fn linear_transform(value: T, slope: f32, intercept: f32) -> T;
+    fn linear_transform(value: T, slope: f64, intercept: f64) -> T;
 
     /// Linearly transform a sequence of values with the given slope and intercept into
     /// a vector.
-    fn linear_transform_many(value: &[T], slope: f32, intercept: f32) -> Vec<T> {
+    fn linear_transform_many(value: &[T], slope: f64, intercept: f64) -> Vec<T> {
         value
             .iter()
             .map(|x| Self::linear_transform(*x, slope, intercept))
@@ -31,7 +31,7 @@ pub trait LinearTransform<T: 'static + Copy> {
     }
 
     /// Linearly transform a sequence of values inline, with the given slope and intercept.
-    fn linear_transform_many_inline(value: &mut [T], slope: f32, intercept: f32) {
+    fn linear_transform_many_inline(value: &mut [T], slope: f64, intercept: f64) {
         for v in value.iter_mut() {
             *v = Self::linear_transform(*v, slope, intercept);
         }
@@ -42,17 +42,17 @@ pub trait LinearTransform<T: 'static + Copy> {
 /// affine transformation, then converted back to the original type. Ideal for
 /// small, low precision types such as `u8` and `i16`.
 #[derive(Debug)]
-pub struct LinearTransformViaF32;
+pub struct LinearTransformViaF32; // TODO remove this for NIFTI-2?
 
 impl<T> LinearTransform<T> for LinearTransformViaF32
 where
     T: 'static + Copy + DataElement,
 {
-    fn linear_transform(value: T, slope: f32, intercept: f32) -> T {
+    fn linear_transform(value: T, slope: f64, intercept: f64) -> T {
         if slope == 0. {
             return value;
         }
-        T::from_f32(AsPrimitive::<f32>::as_(value) * slope + intercept)
+        T::from_f32(AsPrimitive::<f32>::as_(value) * slope as f32 + intercept as f32)
     }
 }
 
@@ -66,7 +66,7 @@ impl<T> LinearTransform<T> for LinearTransformViaF64
 where
     T: 'static + Copy + DataElement,
 {
-    fn linear_transform(value: T, slope: f32, intercept: f32) -> T {
+    fn linear_transform(value: T, slope: f64, intercept: f64) -> T {
         if slope == 0. {
             return value;
         }
@@ -86,12 +86,12 @@ impl<T> LinearTransform<T> for LinearTransformViaOriginal
 where
     T: 'static + Copy + DataElement + Mul<Output = T> + Add<Output = T>,
 {
-    fn linear_transform(value: T, slope: f32, intercept: f32) -> T {
+    fn linear_transform(value: T, slope: f64, intercept: f64) -> T {
         if slope == 0. {
             return value;
         }
-        let slope = T::from_f32(slope);
-        let intercept = T::from_f32(intercept);
+        let slope = T::from_f64(slope);
+        let intercept = T::from_f64(intercept);
         value * slope + intercept
     }
 }

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -66,8 +66,8 @@ macro_rules! fn_convert_and_cast {
 pub struct InMemNiftiVolume {
     dim: Dim,
     datatype: NiftiType,
-    scl_slope: f32,
-    scl_inter: f32,
+    scl_slope: f64,
+    scl_inter: f64,
     raw_data: Vec<u8>,
     endianness: Endianness,
 }
@@ -98,10 +98,10 @@ impl InMemNiftiVolume {
     /// `endianness`, as specified by the volume shape in `raw_dim` and data
     /// type in `datatype`.
     pub fn from_raw_fields(
-        raw_dim: [u16; 8],
+        raw_dim: [u64; 8],
         datatype: NiftiType,
-        scl_slope: f32,
-        scl_inter: f32,
+        scl_slope: f64,
+        scl_inter: f64,
         raw_data: Vec<u8>,
         endianness: Endianness,
     ) -> Result<Self> {
@@ -184,7 +184,7 @@ impl InMemNiftiVolume {
         &mut self.raw_data
     }
 
-    fn get_prim<T>(&self, coords: &[u16]) -> Result<T>
+    fn get_prim<T>(&self, coords: &[u64]) -> Result<T>
     where
         T: DataElement,
         T: Num,
@@ -264,7 +264,7 @@ impl<'a> IntoNdArray for &'a InMemNiftiVolume {
 }
 
 impl<'a> NiftiVolume for &'a InMemNiftiVolume {
-    fn dim(&self) -> &[u16] {
+    fn dim(&self) -> &[u64] {
         (**self).dim()
     }
 
@@ -278,7 +278,7 @@ impl<'a> NiftiVolume for &'a InMemNiftiVolume {
 }
 
 impl NiftiVolume for InMemNiftiVolume {
-    fn dim(&self) -> &[u16] {
+    fn dim(&self) -> &[u64] {
         self.dim.as_ref()
     }
 
@@ -292,85 +292,85 @@ impl NiftiVolume for InMemNiftiVolume {
 }
 
 impl RandomAccessNiftiVolume for InMemNiftiVolume {
-    fn get_f32(&self, coords: &[u16]) -> Result<f32> {
+    fn get_f32(&self, coords: &[u64]) -> Result<f32> {
         self.get_prim(coords)
     }
 
-    fn get_f64(&self, coords: &[u16]) -> Result<f64> {
+    fn get_f64(&self, coords: &[u64]) -> Result<f64> {
         self.get_prim(coords)
     }
 
-    fn get_u8(&self, coords: &[u16]) -> Result<u8> {
+    fn get_u8(&self, coords: &[u64]) -> Result<u8> {
         self.get_prim(coords)
     }
 
-    fn get_i8(&self, coords: &[u16]) -> Result<i8> {
+    fn get_i8(&self, coords: &[u64]) -> Result<i8> {
         self.get_prim(coords)
     }
 
-    fn get_u16(&self, coords: &[u16]) -> Result<u16> {
+    fn get_u16(&self, coords: &[u64]) -> Result<u16> {
         self.get_prim(coords)
     }
 
-    fn get_i16(&self, coords: &[u16]) -> Result<i16> {
+    fn get_i16(&self, coords: &[u64]) -> Result<i16> {
         self.get_prim(coords)
     }
 
-    fn get_u32(&self, coords: &[u16]) -> Result<u32> {
+    fn get_u32(&self, coords: &[u64]) -> Result<u32> {
         self.get_prim(coords)
     }
 
-    fn get_i32(&self, coords: &[u16]) -> Result<i32> {
+    fn get_i32(&self, coords: &[u64]) -> Result<i32> {
         self.get_prim(coords)
     }
 
-    fn get_u64(&self, coords: &[u16]) -> Result<u64> {
+    fn get_u64(&self, coords: &[u64]) -> Result<u64> {
         self.get_prim(coords)
     }
 
-    fn get_i64(&self, coords: &[u16]) -> Result<i64> {
+    fn get_i64(&self, coords: &[u64]) -> Result<i64> {
         self.get_prim(coords)
     }
 }
 
 impl<'a> RandomAccessNiftiVolume for &'a InMemNiftiVolume {
-    fn get_f32(&self, coords: &[u16]) -> Result<f32> {
+    fn get_f32(&self, coords: &[u64]) -> Result<f32> {
         (**self).get_f32(coords)
     }
 
-    fn get_f64(&self, coords: &[u16]) -> Result<f64> {
+    fn get_f64(&self, coords: &[u64]) -> Result<f64> {
         (**self).get_f64(coords)
     }
 
-    fn get_u8(&self, coords: &[u16]) -> Result<u8> {
+    fn get_u8(&self, coords: &[u64]) -> Result<u8> {
         (**self).get_u8(coords)
     }
 
-    fn get_i8(&self, coords: &[u16]) -> Result<i8> {
+    fn get_i8(&self, coords: &[u64]) -> Result<i8> {
         (**self).get_i8(coords)
     }
 
-    fn get_u16(&self, coords: &[u16]) -> Result<u16> {
+    fn get_u16(&self, coords: &[u64]) -> Result<u16> {
         (**self).get_u16(coords)
     }
 
-    fn get_i16(&self, coords: &[u16]) -> Result<i16> {
+    fn get_i16(&self, coords: &[u64]) -> Result<i16> {
         (**self).get_i16(coords)
     }
 
-    fn get_u32(&self, coords: &[u16]) -> Result<u32> {
+    fn get_u32(&self, coords: &[u64]) -> Result<u32> {
         (**self).get_u32(coords)
     }
 
-    fn get_i32(&self, coords: &[u16]) -> Result<i32> {
+    fn get_i32(&self, coords: &[u64]) -> Result<i32> {
         (**self).get_i32(coords)
     }
 
-    fn get_u64(&self, coords: &[u16]) -> Result<u64> {
+    fn get_u64(&self, coords: &[u64]) -> Result<u64> {
         (**self).get_u64(coords)
     }
 
-    fn get_i64(&self, coords: &[u16]) -> Result<i64> {
+    fn get_i64(&self, coords: &[u64]) -> Result<i64> {
         (**self).get_i64(coords)
     }
 }

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -438,15 +438,15 @@ mod tests {
     #[test]
     fn test_false_4d() {
         let (w, h, d) = (5, 5, 5);
-        let mut header = NiftiHeader {
+        let mut header = crate::header::Nifti1Header {
             dim: [4, w, h, d, 1, 1, 1, 1],
             datatype: 2,
             bitpix: 8,
             ..Default::default()
-        };
+        }.into_nifti();
         let raw_data = vec![0; (w * h * d) as usize];
         let mut volume = InMemNiftiVolume::from_raw_data(&header, raw_data).unwrap();
-        assert_eq!(header.dim[0], 4);
+        assert_eq!(header.get_dim()[0], 4);
         assert_eq!(volume.dimensionality(), 4);
         if header.get_dim()[header.get_dim()[0] as usize] == 1 {
             let mut dim = header.get_dim();

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -83,12 +83,12 @@ impl InMemNiftiVolume {
 
         let datatype = header.data_type()?;
         Ok(InMemNiftiVolume {
-            dim: Dim::new(header.dim)?,
+            dim: Dim::new(header.get_dim())?,
             datatype,
-            scl_slope: header.scl_slope,
-            scl_inter: header.scl_inter,
+            scl_slope: header.get_scl_slope(),
+            scl_inter: header.get_scl_inter(),
             raw_data,
-            endianness: header.endianness,
+            endianness: header.get_endianness(),
         })
     }
 
@@ -143,12 +143,12 @@ impl InMemNiftiVolume {
 
         let datatype = header.data_type()?;
         Ok(InMemNiftiVolume {
-            dim: Dim::new(header.dim)?,
+            dim: Dim::new(header.get_dim())?,
             datatype,
-            scl_slope: header.scl_slope,
-            scl_inter: header.scl_inter,
+            scl_slope: header.get_scl_slope(),
+            scl_inter: header.get_scl_inter(),
             raw_data,
-            endianness: header.endianness,
+            endianness: header.get_endianness(),
         })
     }
 
@@ -448,8 +448,10 @@ mod tests {
         let mut volume = InMemNiftiVolume::from_raw_data(&header, raw_data).unwrap();
         assert_eq!(header.dim[0], 4);
         assert_eq!(volume.dimensionality(), 4);
-        if header.dim[header.dim[0] as usize] == 1 {
-            header.dim[0] -= 1;
+        if header.get_dim()[header.get_dim()[0] as usize] == 1 {
+            let mut dim = header.get_dim();
+            dim[0] -= 1;
+            header.set_dim(&dim).unwrap();
             volume = InMemNiftiVolume::from_raw_data(&header, volume.into_raw_data()).unwrap();
         }
         assert_eq!(volume.dimensionality(), 3);

--- a/src/volume/mod.rs
+++ b/src/volume/mod.rs
@@ -29,7 +29,7 @@ pub trait NiftiVolume {
     /// Get the dimensions of the volume. Unlike how NIFTI-1
     /// stores dimensions, the returned slice does not include
     /// `dim[0]` and is clipped to the effective number of dimensions.
-    fn dim(&self) -> &[u16];
+    fn dim(&self) -> &[u64];
 
     /// Get the volume's number of dimensions. In a fully compliant file,
     /// this is equivalent to the corresponding header's `dim[0]` field
@@ -58,7 +58,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     ///
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
     /// volume's boundaries.
-    fn get_f64(&self, coords: &[u16]) -> Result<f64>;
+    fn get_f64(&self, coords: &[u64]) -> Result<f64>;
 
     /// Fetch a single voxel's value in the given voxel index coordinates
     /// as a single precision floating point value.
@@ -72,7 +72,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
     /// volume's boundaries.
     #[inline]
-    fn get_f32(&self, coords: &[u16]) -> Result<f32> {
+    fn get_f32(&self, coords: &[u64]) -> Result<f32> {
         self.get_f64(coords).map(|v| v as f32)
     }
 
@@ -88,7 +88,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
     /// volume's boundaries.
     #[inline]
-    fn get_u8(&self, coords: &[u16]) -> Result<u8> {
+    fn get_u8(&self, coords: &[u64]) -> Result<u8> {
         self.get_f64(coords).map(|v| v as u8)
     }
 
@@ -104,7 +104,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
     /// volume's boundaries.
     #[inline]
-    fn get_i8(&self, coords: &[u16]) -> Result<i8> {
+    fn get_i8(&self, coords: &[u64]) -> Result<i8> {
         self.get_f64(coords).map(|v| v as i8)
     }
 
@@ -120,7 +120,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
     /// volume's boundaries.
     #[inline]
-    fn get_u16(&self, coords: &[u16]) -> Result<u16> {
+    fn get_u16(&self, coords: &[u64]) -> Result<u16> {
         self.get_f64(coords).map(|v| v as u16)
     }
 
@@ -136,7 +136,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
     /// volume's boundaries.
     #[inline]
-    fn get_i16(&self, coords: &[u16]) -> Result<i16> {
+    fn get_i16(&self, coords: &[u64]) -> Result<i16> {
         self.get_f64(coords).map(|v| v as i16)
     }
 
@@ -152,7 +152,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
     /// volume's boundaries.
     #[inline]
-    fn get_u32(&self, coords: &[u16]) -> Result<u32> {
+    fn get_u32(&self, coords: &[u64]) -> Result<u32> {
         self.get_f64(coords).map(|v| v as u32)
     }
 
@@ -168,7 +168,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
     /// volume's boundaries.
     #[inline]
-    fn get_i32(&self, coords: &[u16]) -> Result<i32> {
+    fn get_i32(&self, coords: &[u64]) -> Result<i32> {
         self.get_f64(coords).map(|v| v as i32)
     }
 
@@ -184,7 +184,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
     /// volume's boundaries.
     #[inline]
-    fn get_u64(&self, coords: &[u16]) -> Result<u64> {
+    fn get_u64(&self, coords: &[u64]) -> Result<u64> {
         self.get_f64(coords).map(|v| v as u64)
     }
 
@@ -200,7 +200,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
     /// volume's boundaries.
     #[inline]
-    fn get_i64(&self, coords: &[u16]) -> Result<i64> {
+    fn get_i64(&self, coords: &[u64]) -> Result<i64> {
         self.get_f64(coords).map(|v| v as i64)
     }
 }
@@ -212,7 +212,7 @@ pub trait Sliceable {
 
     /// Obtain a slice of the volume over a certain axis, yielding a
     /// volume of N-1 dimensions.
-    fn get_slice(&self, axis: u16, index: u16) -> Result<Self::Slice>;
+    fn get_slice(&self, axis: u16, index: u64) -> Result<Self::Slice>;
 }
 
 /// Interface for specifying the type for the set of options that are relevent
@@ -243,8 +243,8 @@ pub trait FromSource<R>: FromSourceOptions + Sized {
 pub struct SliceView<T> {
     volume: T,
     axis: u16,
-    index: u16,
-    dim: Vec<u16>,
+    index: u64,
+    dim: Vec<u64>,
 }
 
 impl<'a, T> Sliceable for &'a T
@@ -253,7 +253,7 @@ where
 {
     type Slice = SliceView<&'a T>;
 
-    fn get_slice(&self, axis: u16, index: u16) -> Result<Self::Slice> {
+    fn get_slice(&self, axis: u16, index: u64) -> Result<Self::Slice> {
         let mut coords: Vec<_> = self.dim().into();
         if let Some(d) = coords.get(axis as usize) {
             if *d <= index {
@@ -283,7 +283,7 @@ where
     V: NiftiVolume,
 {
     #[inline]
-    fn dim(&self) -> &[u16] {
+    fn dim(&self) -> &[u64] {
         &self.dim
     }
 
@@ -302,61 +302,61 @@ impl<V> RandomAccessNiftiVolume for SliceView<V>
 where
     V: RandomAccessNiftiVolume,
 {
-    fn get_f32(&self, coords: &[u16]) -> Result<f32> {
+    fn get_f32(&self, coords: &[u64]) -> Result<f32> {
         let mut coords = Vec::from(coords);
         coords.insert(self.axis as usize, self.index);
         self.volume.get_f32(&coords)
     }
 
-    fn get_f64(&self, coords: &[u16]) -> Result<f64> {
+    fn get_f64(&self, coords: &[u64]) -> Result<f64> {
         let mut coords = Vec::from(coords);
         coords.insert(self.axis as usize, self.index);
         self.volume.get_f64(&coords)
     }
 
-    fn get_u8(&self, coords: &[u16]) -> Result<u8> {
+    fn get_u8(&self, coords: &[u64]) -> Result<u8> {
         let mut coords = Vec::from(coords);
         coords.insert(self.axis as usize, self.index);
         self.volume.get_u8(&coords)
     }
 
-    fn get_i8(&self, coords: &[u16]) -> Result<i8> {
+    fn get_i8(&self, coords: &[u64]) -> Result<i8> {
         let mut coords = Vec::from(coords);
         coords.insert(self.axis as usize, self.index);
         self.volume.get_i8(&coords)
     }
 
-    fn get_u16(&self, coords: &[u16]) -> Result<u16> {
+    fn get_u16(&self, coords: &[u64]) -> Result<u16> {
         let mut coords = Vec::from(coords);
         coords.insert(self.axis as usize, self.index);
         self.volume.get_u16(&coords)
     }
 
-    fn get_i16(&self, coords: &[u16]) -> Result<i16> {
+    fn get_i16(&self, coords: &[u64]) -> Result<i16> {
         let mut coords = Vec::from(coords);
         coords.insert(self.axis as usize, self.index);
         self.volume.get_i16(&coords)
     }
 
-    fn get_u32(&self, coords: &[u16]) -> Result<u32> {
+    fn get_u32(&self, coords: &[u64]) -> Result<u32> {
         let mut coords = Vec::from(coords);
         coords.insert(self.axis as usize, self.index);
         self.volume.get_u32(&coords)
     }
 
-    fn get_i32(&self, coords: &[u16]) -> Result<i32> {
+    fn get_i32(&self, coords: &[u64]) -> Result<i32> {
         let mut coords = Vec::from(coords);
         coords.insert(self.axis as usize, self.index);
         self.volume.get_i32(&coords)
     }
 
-    fn get_u64(&self, coords: &[u16]) -> Result<u64> {
+    fn get_u64(&self, coords: &[u64]) -> Result<u64> {
         let mut coords = Vec::from(coords);
         coords.insert(self.axis as usize, self.index);
         self.volume.get_u64(&coords)
     }
 
-    fn get_i64(&self, coords: &[u16]) -> Result<i64> {
+    fn get_i64(&self, coords: &[u64]) -> Result<i64> {
         let mut coords = Vec::from(coords);
         coords.insert(self.axis as usize, self.index);
         self.volume.get_i64(&coords)

--- a/src/volume/streamed.rs
+++ b/src/volume/streamed.rs
@@ -313,20 +313,20 @@ mod tests {
     use super::super::{NiftiVolume, RandomAccessNiftiVolume};
     use super::StreamedNiftiVolume;
     use crate::typedef::NiftiType;
-    use crate::NiftiHeader;
+    use crate::Nifti1Header;
     use byteordered::Endianness;
 
     #[test]
     fn test_streamed_base() {
         let volume_data = &[1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23];
-        let header = NiftiHeader {
+        let header = Nifti1Header {
             dim: [3, 2, 3, 2, 0, 0, 0, 0],
             datatype: NiftiType::Uint8 as i16,
             scl_slope: 1.,
             scl_inter: 0.,
             endianness: Endianness::native(),
-            ..NiftiHeader::default()
-        };
+            ..Nifti1Header::default()
+        }.into_nifti();
 
         let mut volume = StreamedNiftiVolume::from_reader(&volume_data[..], &header).unwrap();
 
@@ -360,14 +360,14 @@ mod tests {
     #[test]
     fn test_streamed_indexed() {
         let volume_data = &[1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23];
-        let header = NiftiHeader {
+        let header = Nifti1Header {
             dim: [3, 2, 3, 2, 0, 0, 0, 0],
             datatype: NiftiType::Uint8 as i16,
             scl_slope: 1.,
             scl_inter: 0.,
             endianness: Endianness::native(),
-            ..NiftiHeader::default()
-        };
+            ..Nifti1Header::default()
+        }.into_nifti();
 
         let mut volume = StreamedNiftiVolume::from_reader(&volume_data[..], &header).unwrap();
 
@@ -404,14 +404,14 @@ mod tests {
     #[test]
     fn test_streamed_inline() {
         let volume_data = &[1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23];
-        let header = NiftiHeader {
+        let header = Nifti1Header {
             dim: [3, 2, 3, 2, 0, 0, 0, 0],
             datatype: NiftiType::Uint8 as i16,
             scl_slope: 1.,
             scl_inter: 0.,
             endianness: Endianness::native(),
-            ..NiftiHeader::default()
-        };
+            ..Nifti1Header::default()
+        }.into_nifti();
 
         let mut volume = StreamedNiftiVolume::from_reader(&volume_data[..], &header).unwrap();
 
@@ -446,14 +446,14 @@ mod tests {
     #[test]
     fn test_streamed_ranked() {
         let volume_data = &[1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23];
-        let header = NiftiHeader {
+        let header = Nifti1Header {
             dim: [4, 2, 3, 2, 1, 0, 0, 0],
             datatype: NiftiType::Uint8 as i16,
             scl_slope: 1.,
             scl_inter: 0.,
             endianness: Endianness::native(),
-            ..NiftiHeader::default()
-        };
+            ..Nifti1Header::default()
+        }.into_nifti();
 
         let mut volume =
             StreamedNiftiVolume::from_reader_rank(&volume_data[..], &header, 2).unwrap();
@@ -490,14 +490,14 @@ mod tests {
         let volume_data = &[
             1, 0, 3, 0, 5, 0, 7, 0, 9, 0, 11, 0, 13, 0, 15, 0, 17, 0, 19, 0, 21, 0, 23, 0,
         ];
-        let header = NiftiHeader {
+        let header = Nifti1Header {
             dim: [3, 2, 3, 2, 0, 0, 0, 0],
             datatype: NiftiType::Uint16 as i16,
             scl_slope: 1.,
             scl_inter: 0.,
             endianness: Endianness::Little,
-            ..NiftiHeader::default()
-        };
+            ..Nifti1Header::default()
+        }.into_nifti();
 
         let mut volume =
             StreamedNiftiVolume::from_reader_rank(&volume_data[..], &header, 1).unwrap();

--- a/src/volume/streamed.rs
+++ b/src/volume/streamed.rs
@@ -78,8 +78,8 @@ pub struct StreamedNiftiVolume<R> {
     dim: Dim,
     slice_dim: Dim,
     datatype: NiftiType,
-    scl_slope: f32,
-    scl_inter: f32,
+    scl_slope: f64,
+    scl_inter: f64,
     endianness: Endianness,
     slices_read: usize,
     slices_left: usize,
@@ -141,12 +141,12 @@ where
     }
 
     /// Retrieve the full volume shape.
-    pub fn dim(&self) -> &[u16] {
+    pub fn dim(&self) -> &[u64] {
         self.dim.as_ref()
     }
 
     /// Retrieve the shape of the slices.
-    pub fn slice_dim(&self) -> &[u16] {
+    pub fn slice_dim(&self) -> &[u64] {
         self.slice_dim.as_ref()
     }
 
@@ -245,7 +245,7 @@ where
 }
 
 impl<'a, R> NiftiVolume for &'a StreamedNiftiVolume<R> {
-    fn dim(&self) -> &[u16] {
+    fn dim(&self) -> &[u64] {
         (**self).dim()
     }
 
@@ -259,7 +259,7 @@ impl<'a, R> NiftiVolume for &'a StreamedNiftiVolume<R> {
 }
 
 impl<R> NiftiVolume for StreamedNiftiVolume<R> {
-    fn dim(&self) -> &[u16] {
+    fn dim(&self) -> &[u64] {
         self.dim.as_ref()
     }
 
@@ -297,7 +297,7 @@ fn calculate_slice_dims(dim: &Dim, slice_rank: u16) -> Dim {
     assert!(dim.rank() > 0);
     assert!(usize::from(slice_rank) < dim.rank());
     let mut raw_dim = *dim.raw();
-    raw_dim[0] = slice_rank;
+    raw_dim[0] = slice_rank as u64;
     Dim::new(raw_dim).unwrap()
 }
 

--- a/src/volume/streamed.rs
+++ b/src/volume/streamed.rs
@@ -110,7 +110,7 @@ where
     ///
     /// By default, the slice's rank is the original volume's rank minus 1.
     pub fn from_reader(source: R, header: &NiftiHeader) -> Result<Self> {
-        let dim = Dim::new(header.dim)?;
+        let dim = Dim::new(header.get_dim())?;
         let slice_rank = dim.rank() - 1;
         StreamedNiftiVolume::from_reader_rank(source, header, slice_rank as u16)
     }
@@ -123,7 +123,7 @@ where
     /// The slice rank defines how many dimensions each slice should have.
     pub fn from_reader_rank(source: R, header: &NiftiHeader, slice_rank: u16) -> Result<Self> {
         // TODO recoverable error if #dim == 0
-        let dim = Dim::new(header.dim)?; // check dim consistency
+        let dim = Dim::new(header.get_dim())?; // check dim consistency
         let datatype = header.data_type()?;
         let slice_dim = calculate_slice_dims(&dim, slice_rank);
         let slices_left = calculate_total_slices(&dim, slice_rank);
@@ -132,9 +132,9 @@ where
             dim,
             slice_dim,
             datatype,
-            scl_slope: header.scl_slope,
-            scl_inter: header.scl_inter,
-            endianness: header.endianness,
+            scl_slope: header.get_scl_slope(),
+            scl_inter: header.get_scl_inter(),
+            endianness: header.get_endianness(),
             slices_read: 0,
             slices_left,
         })

--- a/src/volume/util.rs
+++ b/src/volume/util.rs
@@ -12,7 +12,7 @@ where
     v
 }
 
-pub fn coords_to_index(coords: &[u16], dim: &[u16]) -> Result<usize> {
+pub fn coords_to_index(coords: &[u64], dim: &[u64]) -> Result<usize> {
     if coords.len() != dim.len() || coords.is_empty() {
         return Err(NiftiError::IncorrectVolumeDimensionality(
             dim.len() as u16,
@@ -20,7 +20,7 @@ pub fn coords_to_index(coords: &[u16], dim: &[u16]) -> Result<usize> {
         ));
     }
 
-    if !coords.iter().zip(dim).all(|(i, d)| *i < (*d) as u16) {
+    if !coords.iter().zip(dim).all(|(i, d)| *i < *d) {
         return Err(NiftiError::OutOfBounds(Vec::from(coords)));
     }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -11,10 +11,10 @@ use ndarray::{ArrayBase, Axis, Data, Dimension, RemoveAxis};
 use safe_transmute::{transmute_to_bytes, TriviallyTransmutable};
 
 use crate::{
-    header::{MAGIC_CODE_NI1, MAGIC_CODE_NIP1},
+    header::{MAGIC_CODE_NI1, MAGIC_CODE_NIP1, MAGIC_CODE_NI2, MAGIC_CODE_NIP2},
     util::{adapt_bytes, is_gz_file, is_hdr_file},
     volume::shape::Dim,
-    DataElement, NiftiHeader, NiftiType, Result,
+    DataElement, NiftiHeader, Nifti1Header, Nifti2Header, NiftiType, Result,
 };
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -304,7 +304,7 @@ where
     W: Write,
     E: Endian,
 {
-    writer.write_i32(header.sizeof_hdr)?;
+    writer.write_i32(header.sizeof_hdr as i32)?;
     writer.write_all(&header.data_type)?;
     writer.write_all(&header.db_name)?;
     writer.write_i32(header.extents)?;
@@ -319,17 +319,17 @@ where
     writer.write_f32(header.intent_p3)?;
     writer.write_i16(header.intent_code)?;
     writer.write_i16(header.datatype)?;
-    writer.write_i16(header.bitpix)?;
-    writer.write_i16(header.slice_start)?;
+    writer.write_i16(header.bitpix.try_into()?)?;
+    writer.write_i16(header.slice_start.try_into()?)?;
     for f in &header.pixdim {
         writer.write_f32(*f)?;
     }
     writer.write_f32(header.vox_offset)?;
     writer.write_f32(header.scl_slope)?;
     writer.write_f32(header.scl_inter)?;
-    writer.write_i16(header.slice_end)?;
-    writer.write_u8(header.slice_code)?;
-    writer.write_u8(header.xyzt_units)?;
+    writer.write_i16(header.slice_end.try_into()?)?;
+    writer.write_i8(header.slice_code)?;
+    writer.write_i8(header.xyzt_units)?;
     writer.write_f32(header.cal_max)?;
     writer.write_f32(header.cal_min)?;
     writer.write_f32(header.slice_duration)?;

--- a/tests/affine.rs
+++ b/tests/affine.rs
@@ -14,19 +14,19 @@ mod nalgebra_affine {
         let affine = Affine4::from_diagonal(&Vector4::new(2.0, 2.0, 2.0, 1.0));
         header.set_affine(&affine);
         assert_eq!(affine, header.affine());
-        assert_eq!(header.sform_code, 2);
-        assert_eq!(header.qform_code, 0);
+        assert_eq!(header.get_sform_code(), 2);
+        assert_eq!(header.get_qform_code(), 0);
     }
 
     #[test]
     #[rustfmt::skip]
     fn sform() {
         let mut header = NiftiHeader::default();
-        header.sform_code = 1;
-        header.qform_code = 0;
-        header.srow_x = [2.4, -0.0008, -0.0411765, -114.766396];
-        header.srow_y = [0.1, 2.4995277, 0.0485984, -97.420204];
-        header.srow_z = [0.4, -0.0485, 2.4991884, -89.12282];
+        header.set_sform_code(1).unwrap();
+        header.set_qform_code(0).unwrap();
+        header.set_srow_x(&[2.4, -0.0008, -0.0411765, -114.766396]);
+        header.set_srow_y(&[0.1, 2.4995277, 0.0485984, -97.420204]);
+        header.set_srow_z(&[0.4, -0.0485, 2.4991884, -89.12282]);
 
         let real_affine = Affine4::new(
             2.4, -0.0008,    -0.0411765, -114.766396,
@@ -41,15 +41,15 @@ mod nalgebra_affine {
     #[rustfmt::skip]
     fn qform() {
         let mut header = NiftiHeader::default();
-        header.sform_code = 0;
-        header.qform_code = 1;
-        header.pixdim = [-1.0, 0.9375, 0.9375, 3.0, 0.0, 0.0, 0.0, 0.0];
-        header.quatern_b = 0.0;
-        header.quatern_c = 1.0;
-        header.quatern_d = 0.0;
-        header.quatern_x = 59.557503;
-        header.quatern_y = 73.172;
-        header.quatern_z = 43.4291;
+        header.set_sform_code(0).unwrap();
+        header.set_qform_code(1).unwrap();
+        header.set_pixdim(&[-1.0, 0.9375, 0.9375, 3.0, 0.0, 0.0, 0.0, 0.0]);
+        header.set_quatern_b(0.0);
+        header.set_quatern_c(1.0);
+        header.set_quatern_d(0.0);
+        header.set_quatern_x(59.557503);
+        header.set_quatern_y(73.172);
+        header.set_quatern_z(43.4291);
 
         let real_affine = Affine4::new(
             -0.9375, 0.0,    0.0, 59.557503,
@@ -64,20 +64,20 @@ mod nalgebra_affine {
     #[rustfmt::skip]
     fn both_valid() {
         let mut header = NiftiHeader::default();
-        header.sform_code = 1;
-        header.srow_x = [2.4, 0.0, 0.0, -114.766396];
-        header.srow_y = [0.1, 2.4, 0.0, -97.420204];
-        header.srow_z = [0.4, 0.4, 2.4, -89.12282];
+        header.set_sform_code(1).unwrap();
+        header.set_srow_x(&[2.4, 0.0, 0.0, -114.766396]);
+        header.set_srow_y(&[0.1, 2.4, 0.0, -97.420204]);
+        header.set_srow_z(&[0.4, 0.4, 2.4, -89.12282]);
 
         // All this should be ignored
-        header.qform_code = 1;
-        header.pixdim = [-1.0, 0.9375, 0.9375, 3.0, 0.0, 0.0, 0.0, 0.0];
-        header.quatern_b = 0.0;
-        header.quatern_c = 1.0;
-        header.quatern_d = 0.0;
-        header.quatern_x = 59.0;
-        header.quatern_y = 73.0;
-        header.quatern_z = 43.0;
+        header.set_qform_code(1).unwrap();
+        header.set_pixdim(&[-1.0, 0.9375, 0.9375, 3.0, 0.0, 0.0, 0.0, 0.0]);
+        header.set_quatern_b(0.0);
+        header.set_quatern_c(1.0);
+        header.set_quatern_d(0.0);
+        header.set_quatern_x(59.0);
+        header.set_quatern_y(73.0);
+        header.set_quatern_z(43.0);
 
         let real_affine = Affine4::new(
             2.4, 0.0, 0.0, -114.766396,
@@ -92,21 +92,21 @@ mod nalgebra_affine {
     #[rustfmt::skip]
     fn none_valid() {
         let mut header = NiftiHeader::default();
-        header.dim = [3, 100, 100, 100, 0, 0, 0, 0];
-        header.pixdim = [-1.0, 0.9, 0.9, 3.0, 0.0, 0.0, 0.0, 0.0];
+        header.set_dim(&[3, 100, 100, 100, 0, 0, 0, 0]).unwrap();
+        header.set_pixdim(&[-1.0, 0.9, 0.9, 3.0, 0.0, 0.0, 0.0, 0.0]);
 
         // All this should be ignored, because only `shape_zoom_affine` will be called.
-        header.sform_code = 0;
-        header.srow_x = [1.0, 0.0, 0.0, 1.0];
-        header.srow_y = [0.0, 1.0, 0.0, 1.0];
-        header.srow_z = [0.0, 0.0, 1.0, 1.0];
-        header.qform_code = 0;
-        header.quatern_b = 0.0;
-        header.quatern_c = 1.0;
-        header.quatern_d = 0.0;
-        header.quatern_x = 59.0;
-        header.quatern_y = 73.0;
-        header.quatern_z = 43.0;
+        header.set_sform_code(0).unwrap();
+        header.set_srow_x(&[1.0, 0.0, 0.0, 1.0]);
+        header.set_srow_y(&[0.0, 1.0, 0.0, 1.0]);
+        header.set_srow_z(&[0.0, 0.0, 1.0, 1.0]);
+        header.set_qform_code(0).unwrap();
+        header.set_quatern_b(0.0);
+        header.set_quatern_c(1.0);
+        header.set_quatern_d(0.0);
+        header.set_quatern_x(59.0);
+        header.set_quatern_y(73.0);
+        header.set_quatern_z(43.0);
 
         let real_affine = Affine4::new(
             -0.9, 0.0, 0.0,   44.55,

--- a/tests/header.rs
+++ b/tests/header.rs
@@ -2,7 +2,7 @@ extern crate nifti;
 #[macro_use]
 extern crate pretty_assertions;
 
-use nifti::{Endianness, Intent, NiftiHeader, NiftiType, SliceOrder, Unit, XForm};
+use nifti::{Endianness, Intent, NiftiHeader, Nifti1Header, NiftiType, SliceOrder, Unit, XForm};
 use std::fs::File;
 
 mod util;
@@ -52,7 +52,7 @@ fn minimal_nii() {
     let header = NiftiHeader::from_reader(file).unwrap();
 
     assert_eq!(header, minimal_hdr);
-    assert_eq!(header.endianness, Endianness::Big);
+    assert_eq!(header.get_endianness(), Endianness::Big);
 
     assert_eq!(header.intent().unwrap(), Intent::None);
     assert_eq!(header.data_type().unwrap(), NiftiType::Uint8);
@@ -65,10 +65,9 @@ fn minimal_nii() {
 #[test]
 #[allow(non_snake_case)]
 fn avg152T1_LR_hdr_gz() {
-    let mut descrip = Vec::with_capacity(80);
-    descrip.extend(b"FSL3.2beta");
-    descrip.resize(80, 0);
-    let avg152t1_lr_hdr = NiftiHeader {
+    let mut descrip = [0; 80];
+    descrip[..10].copy_from_slice(b"FSL3.2beta");
+    let avg152t1_lr_hdr = Nifti1Header {
         sizeof_hdr: 348,
         regular: b'r',
         dim: [3, 91, 109, 91, 1, 1, 1, 1],
@@ -91,13 +90,13 @@ fn avg152T1_LR_hdr_gz() {
         magic: *b"ni1\0",
         endianness: Endianness::Big,
         ..Default::default()
-    };
+    }.into_nifti();
 
     const FILE_NAME: &str = "resources/avg152T1_LR_nifti.hdr.gz";
     let header = NiftiHeader::from_file(FILE_NAME).unwrap();
 
     assert_eq!(header, avg152t1_lr_hdr);
-    assert_eq!(header.endianness, Endianness::Big);
+    assert_eq!(header.get_endianness(), Endianness::Big);
 
     assert_eq!(header.intent().unwrap(), Intent::None);
     assert_eq!(header.data_type().unwrap(), NiftiType::Uint8);
@@ -110,10 +109,9 @@ fn avg152T1_LR_hdr_gz() {
 #[test]
 #[allow(non_snake_case)]
 fn avg152T1_LR_nii_gz() {
-    let mut descrip = Vec::with_capacity(80);
-    descrip.extend(b"FSL3.2beta");
-    descrip.resize(80, 0);
-    let avg152t1_lr_hdr = NiftiHeader {
+    let mut descrip = [0; 80];
+    descrip[..10].copy_from_slice(b"FSL3.2beta");
+    let avg152t1_lr_hdr = Nifti1Header {
         sizeof_hdr: 348,
         regular: b'r',
         dim: [3, 91, 109, 91, 1, 1, 1, 1],
@@ -136,7 +134,7 @@ fn avg152T1_LR_nii_gz() {
         magic: *b"n+1\0",
         endianness: Endianness::Big,
         ..Default::default()
-    };
+    }.into_nifti();
 
     const FILE_NAME: &str = "resources/avg152T1_LR_nifti.nii.gz";
     let header = NiftiHeader::from_file(FILE_NAME).unwrap();
@@ -153,10 +151,9 @@ fn avg152T1_LR_nii_gz() {
 
 #[test]
 fn zstat1_nii_gz() {
-    let mut descrip = Vec::with_capacity(80);
-    descrip.extend(b"FSL3.2beta");
-    descrip.resize(80, 0);
-    let zstat1_hdr = NiftiHeader {
+    let mut descrip = [0; 80];
+    descrip[..10].copy_from_slice(b"FSL3.2beta");
+    let zstat1_hdr = Nifti1Header {
         sizeof_hdr: 348,
         regular: b'r',
         dim: [3, 64, 64, 21, 1, 1, 1, 1],
@@ -181,7 +178,7 @@ fn zstat1_nii_gz() {
         magic: *b"n+1\0",
         endianness: Endianness::Big,
         ..Default::default()
-    };
+    }.into_nifti();
 
     const FILE_NAME: &str = "resources/zstat1.nii.gz";
     let header = NiftiHeader::from_file(FILE_NAME).unwrap();

--- a/tests/object.rs
+++ b/tests/object.rs
@@ -6,7 +6,7 @@ extern crate nifti;
 extern crate pretty_assertions;
 
 use nifti::{
-    Endianness, NiftiHeader, NiftiObject, NiftiType, NiftiVolume, RandomAccessNiftiVolume,
+    Endianness, Nifti1Header, NiftiObject, NiftiType, NiftiVolume, RandomAccessNiftiVolume,
     ReaderOptions, ReaderStreamedOptions, XForm,
 };
 
@@ -128,7 +128,7 @@ fn minimal_by_pair() {
 
 #[test]
 fn f32_nii_gz() {
-    let f32_hdr = NiftiHeader {
+    let f32_hdr = Nifti1Header {
         sizeof_hdr: 348,
         dim: [3, 11, 11, 11, 1, 1, 1, 1],
         datatype: 16,
@@ -144,7 +144,7 @@ fn f32_nii_gz() {
         magic: *b"n+1\0",
         endianness: Endianness::Little,
         ..Default::default()
-    };
+    }.into_nifti();
 
     const FILE_NAME: &str = "resources/f32.nii.gz";
     let obj = ReaderOptions::new().read_file(FILE_NAME).unwrap();
@@ -166,7 +166,7 @@ fn f32_nii_gz() {
 
 #[test]
 fn streamed_f32_nii_gz() {
-    let f32_hdr = NiftiHeader {
+    let f32_hdr = Nifti1Header {
         sizeof_hdr: 348,
         dim: [3, 11, 11, 11, 1, 1, 1, 1],
         datatype: 16,
@@ -182,7 +182,7 @@ fn streamed_f32_nii_gz() {
         magic: *b"n+1\0",
         endianness: Endianness::Little,
         ..Default::default()
-    };
+    }.into_nifti();
 
     const FILE_NAME: &str = "resources/f32.nii.gz";
     let obj = ReaderStreamedOptions::new().read_file(FILE_NAME).unwrap();

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,18 +1,18 @@
-use nifti::{Endianness, NiftiHeader, NiftiType};
+use nifti::{Endianness, NiftiHeader, Nifti1Header, NiftiType};
 
 /// Known meta-data for the "minimal.nii" test file.
 #[allow(dead_code)]
 pub fn minimal_header_nii_gt() -> NiftiHeader {
-    NiftiHeader {
+    Nifti1Header {
         vox_offset: 352.,
         magic: *b"n+1\0",
-        ..minimal_header_hdr_gt()
-    }
+        ..minimal_header_hdr_gt().into_nifti1().unwrap()
+    }.into_nifti()
 }
 
 /// Known meta-data for the "minimal.hdr" test file.
 pub fn minimal_header_hdr_gt() -> NiftiHeader {
-    NiftiHeader {
+    Nifti1Header {
         sizeof_hdr: 348,
         dim: [3, 64, 64, 10, 0, 0, 0, 0],
         datatype: NiftiType::Uint8 as i16,
@@ -29,17 +29,17 @@ pub fn minimal_header_hdr_gt() -> NiftiHeader {
         magic: *b"ni1\0",
         endianness: Endianness::Big,
         ..Default::default()
-    }
+    }.into_nifti()
 }
 
 /// Known meta-data for the RGB volume test file.
 #[allow(dead_code)]
 pub fn rgb_header_gt() -> NiftiHeader {
-    NiftiHeader {
+    Nifti1Header {
         datatype: NiftiType::Rgb24 as i16,
         sform_code: 2,
         qform_code: 0,
         endianness: Endianness::Little,
-        ..NiftiHeader::default()
-    }
+        ..Default::default()
+    }.into_nifti()
 }


### PR DESCRIPTION
Adds support for the NIFTI-2 header format.  The PR is just enough to compile and run tests.  If approved, documentation and additional test cases will be needed in a subsequent PR.  These changes are _**not**_ backwards compatible.

* Types and methods outside the header have been changed to default to the larger NIFTI-2 types.  For example, `nifti::volume::shape::Dim` is now based off `u64` instead of `u16`.

* `NiftiHeader` is changed to an `enum` that contains either a `Nifti1Header` or `Nifti2Header` structure.  `NiftiHeader` implements getter/setter methods to modify the underlying header without having to worry about which version it is.  The underlying structure can also be accessed directly.

```rust
hdr = NiftiHeader::default();
hdr.slice_duration = 1.0; // no longer works
hdr.set_slice_duration(1.0); // OK
let slice_duration: f32 = hdr.get_slice_duration(); // no longer works
let slice_duration: f64 = hdr.get_slice_duration(); // OK
// Conversion to larger NIFTI-2 types always succeeds.
let mut hdr2: Nifti2Header = hdr.into_nifti2();
hdr2.slice_duration = 1.0; // OK
let slice_duration: f64 = hdr2.slice_duration; // OK
// Conversion to smaller NIFTI-1 types is fallible.
let mut hdr1: Nifti1Header = hdr.into_nifti1().unwrap();
hdr1.slice_duration = 1.0; // OK
let slice_duration: f32 = hdr1.slice_duration; // OK
```

Migration should otherwise be relatively painless.
* `NiftiHeader::from_file()` and `from_reader()` automatically detect the header version in the given file or input stream.
* `WriterOptions::write_nifti()` automatically writes out whichever header version is referenced by the `WriterOptions`.
* `NiftiHeader::into_nifti1()` and `into_nifti2()` conveniently convert between header versions.