### PR TITLE
Update dependencies (2022-05)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ optional = true
 version = "0.5"
 
 [dev-dependencies]
-pretty_assertions = "0.7"
+pretty_assertions = "1.2.1"
 tempfile = "3.1"
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["resources/*"]
 features = ["ndarray_volumes", "nalgebra_affine"]
 
 [dependencies]
-approx = "0.4"
+approx = "0.5"
 byteordered = "0.6"
 flate2 = "1.0"
 num-derive = "0.3"
@@ -32,7 +32,7 @@ version = "0.31"
 [dependencies.ndarray]
 optional = true
 version = "0.15"
-features = ["approx"]
+features = ["approx-0_5"]
 
 [dependencies.simba]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,9 @@ exclude = ["resources/*"]
 [package.metadata.docs.rs]
 features = ["ndarray_volumes", "nalgebra_affine"]
 
-[badges]
-
 [dependencies]
 approx = "0.4"
-byteordered = "0.5"
+byteordered = "0.6"
 flate2 = "1.0"
 num-derive = "0.3"
 num-traits = "0.2"
@@ -29,7 +27,7 @@ either = "1.6"
 
 [dependencies.nalgebra]
 optional = true
-version = "0.27"
+version = "0.31"
 
 [dependencies.ndarray]
 optional = true
@@ -39,7 +37,7 @@ features = ["approx"]
 [dependencies.simba]
 default-features = false
 optional = true
-version = "0.5"
+version = "0.7.1"
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/src/header.rs
+++ b/src/header.rs
@@ -519,7 +519,7 @@ impl NiftiHeader {
         T: SubsetOf<f64>,
         T: ToPrimitive,
     {
-        let affine4: Matrix4<f64> = nalgebra::convert(*affine4);
+        let affine4: Matrix4<f64> = nalgebra::convert(affine4.clone());
         let (affine, translation) = affine_and_translation(&affine4);
         let aff2 = affine.component_mul(&affine);
         let spacing = (


### PR DESCRIPTION
- Update dependencies (non-breaking)
   - pretty_assertions
- Update dependencies (breaking)
   - byteordered 0.6
   - nalgebra 0.31
   - simba 0.7.1

Cannot update approx until rust-ndarray/ndarray#1062 is resolved.