### PR TITLE
NIfTI-2 Support

### DIFF
--- a/src/affine.rs
+++ b/src/affine.rs
@@ -23,7 +23,7 @@ where
 ///
 /// We get the translations from the center of the image (implied by `shape`).
 #[rustfmt::skip]
-pub(crate) fn shape_zoom_affine(shape: &[u16], spacing: &[f32]) -> Matrix4<f64> {
+pub(crate) fn shape_zoom_affine(shape: &[u64], spacing: &[f64]) -> Matrix4<f64> {
     // Get translations from center of image
     let origin = Vector3::new(
         (shape[0] as f64 - 1.0) / 2.0,

--- a/src/error.rs
+++ b/src/error.rs
@@ -72,6 +72,16 @@ quick_error! {
         InvalidCode(typename: &'static str, code: i16) {
             display("invalid code `{}` for header field {}", code, typename)
         }
+        /// Integer field size is not large enough to hold assigned value
+        FieldSize(err: std::num::TryFromIntError) {
+            from()
+            source(err)
+        }
+        /// Invalid header size.  Header size must be 540 for NIfTI-2 or 348 for
+        /// NIfTI-1.
+        InvalidHeaderSize(sizeof_hdr: i32) {
+            display("Invalid header size {} must eb 540 for NIfTI-2 or 348 for NIfTI-1.", sizeof_hdr)
+        }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,14 +16,14 @@ quick_error! {
         /// The field `dim` is in an invalid state, as a consequence of
         /// `dim[0]` or one of the elements in `1..dim[0] + 1` not being
         /// positive.
-        InconsistentDim(index: u8, value: u16) {
+        InconsistentDim(index: u8, value: u64) {
             display("Inconsistent value `{}` in header field dim[{}] ({})", value, index, match index {
                 0 if *value > 7 => "must not be higher than 7",
                 _ => "must be positive"
             })
         }
         /// Attempted to read volume outside boundaries.
-        OutOfBounds(coords: Vec<u16>) {
+        OutOfBounds(coords: Vec<u64>) {
             display("Out of bounds access to volume: {:?}", &coords[..])
         }
         /// Attempted to read a volume over a volume's unexistent dimension.
@@ -69,7 +69,7 @@ quick_error! {
             display("Description length ({} bytes) is greater than 80 bytes.", len)
         }
         /// Header contains a code which is not valid for the given attribute
-        InvalidCode(typename: &'static str, code: i16) {
+        InvalidCode(typename: &'static str, code: i32) {
             display("invalid code `{}` for header field {}", code, typename)
         }
         /// Integer field size is not large enough to hold assigned value

--- a/src/header.rs
+++ b/src/header.rs
@@ -69,7 +69,7 @@ pub const MAGIC_CODE_NIP2: &[u8; 8] = b"n+2\0\r\n\x1A\n";
 /// // Convert a header into NIFTI-2 (does nothing if already NIFTI-2).
 /// // First extracts/converts the `NiftiHeader` into a `Nifti2Header` and then
 /// // puts it back into a `NiftiHeader`.
-/// let hdr4 = hdr3.into_nifti2().into_nifti();
+/// let hdr4:NiftiHeader = hdr3.into_nifti2().into();
 ///
 /// // Make a new header from scratch.  Defaults to NIFTI-2.
 /// let mut hdr5 = NiftiHeader::default();
@@ -89,7 +89,7 @@ pub enum NiftiHeader {
 }
 impl Default for NiftiHeader {
     fn default() -> NiftiHeader {
-        Nifti2Header::default().into_nifti() // default to NIfTI-2 format
+        Nifti2Header::default().into() // default to NIfTI-2 format
     }
 }
 impl NiftiHeader {
@@ -845,13 +845,13 @@ impl NiftiHeader {
         // 469893120 for NIfTI-2 or 1543569408 for NIfTI-2.
         match sizeof_hdr {
             // NIfTI-2 native endian
-            540 => Ok(parse_nifti2_header(input, 540)?.into_nifti()),
+            540 => Ok(parse_nifti2_header(input, 540)?.into()),
             // NIfTI-2 swap endian
-            469893120 => Ok(parse_nifti2_header(input.into_opposite(), 348)?.into_nifti()),
+            469893120 => Ok(parse_nifti2_header(input.into_opposite(), 348)?.into()),
             // NIfTI-1 native endian
-            348 => Ok(parse_nifti1_header(input, 348)?.into_nifti()),
+            348 => Ok(parse_nifti1_header(input, 348)?.into()),
             // NIfTI-1 swap endian
-            1543569408 => Ok(parse_nifti1_header(input.into_opposite(), 348)?.into_nifti()),
+            1543569408 => Ok(parse_nifti1_header(input.into_opposite(), 348)?.into()),
             // Invalid header size
             _ => Err(NiftiError::InvalidHeaderSize(sizeof_hdr)),
         }
@@ -1138,7 +1138,7 @@ impl NiftiHeader {
 /// hdr.datatype = 4;
 /// assert_eq!(hdr.cal_min, 0.);
 /// assert_eq!(hdr.cal_max, 128.);
-/// let hdr: NiftiHeader = hdr.into_nifti();
+/// let hdr: NiftiHeader = hdr.into();
 /// assert_eq!(hdr.data_type().unwrap(), NiftiType::Int16);
 /// ```
 #[derive(Debug, Clone, PartialEq)]
@@ -1261,7 +1261,7 @@ pub struct Nifti1Header {
 /// hdr.datatype = 4;
 /// assert_eq!(hdr.cal_min, 0.);
 /// assert_eq!(hdr.cal_max, 128.);
-/// let hdr: NiftiHeader = hdr.into_nifti();
+/// let hdr: NiftiHeader = hdr.into();
 /// assert_eq!(hdr.data_type().unwrap(), NiftiType::Int16);
 /// ```
 #[derive(Debug, Clone, PartialEq)]
@@ -1451,16 +1451,16 @@ impl Default for Nifti2Header {
     }
 }
 
-impl Nifti1Header {
+impl Into<NiftiHeader> for Nifti1Header {
     /// Place this `Nifti1Header` into a version-agnostic [`NiftiHeader`] enum.
-    pub fn into_nifti(self) -> NiftiHeader {
+    fn into(self) -> NiftiHeader {
         NiftiHeader::Nifti1Header(self)
     }
 }
 
-impl Nifti2Header {
+impl Into<NiftiHeader> for Nifti2Header {
     /// Place this `Nifti2Header` into a version-agnostic [`NiftiHeader`] enum.
-    pub fn into_nifti(self) -> NiftiHeader {
+    fn into(self) -> NiftiHeader {
         NiftiHeader::Nifti2Header(self)
     }
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -32,7 +32,7 @@ pub const MAGIC_CODE_NIP2: &[u8; 8] = b"n+2\0\r\n\x1A\n";
 
 /// Abstraction over NIFTI version 1 and 2 headers.  This is the high-level type
 /// you will likely use most often.
-/// 
+///
 /// The NIFTI file format has two different versions for headers.  NIFTI-1 was
 /// finalized in 2007 and is still widely used by many scanner manufacturers.
 /// NIFTI-2 was created in 2011 and is widely used in many research-oriented
@@ -41,7 +41,7 @@ pub const MAGIC_CODE_NIP2: &[u8; 8] = b"n+2\0\r\n\x1A\n";
 /// and removal of some unused fields.  Refer to the
 /// [reference documentation](https://nifti.nimh.nih.gov/pub/dist/doc/nifti2.h)
 /// for a comprehensive list of changes.
-/// 
+///
 /// For practical purposes, there is no difference between the header versions.
 /// This `NiftiHeader` type is an `enum` storing either a `Nifti2Header` or
 /// `Nifti1Header`.  Calling `from_file()` or `from_reader()` automatically
@@ -50,10 +50,10 @@ pub const MAGIC_CODE_NIP2: &[u8; 8] = b"n+2\0\r\n\x1A\n";
 /// `set_slice_duration()`, and high-level methods like `data_type()`,
 /// automatically convert values to/from the appropriate underlying type
 /// depending on the header version.
-/// 
+///
 /// If you must work with a specific header version, you can easily convert
 /// between versions with `into_nifti1()` or `into_nifti2()`.
-/// 
+///
 /// # Examples
 ///
 /// ```no_run
@@ -65,15 +65,15 @@ pub const MAGIC_CODE_NIP2: &[u8; 8] = b"n+2\0\r\n\x1A\n";
 /// let hdr1 = NiftiHeader::from_file("0000.hdr")?;
 /// let hdr2 = NiftiHeader::from_file("0001.hdr.gz")?;
 /// let hdr3 = NiftiHeader::from_file("4321.nii.gz")?;
-/// 
+///
 /// // Convert a header into NIFTI-2 (does nothing if already NIFTI-2).
 /// // First extracts/converts the `NiftiHeader` into a `Nifti2Header` and then
 /// // puts it back into a `NiftiHeader`.
 /// let hdr4 = hdr3.into_nifti2().into_nifti();
-/// 
+///
 /// // Make a new header from scratch.  Defaults to NIFTI-2.
 /// let mut hdr5 = NiftiHeader::default();
-/// 
+///
 /// // Change the slice duration to two-and-a-half seconds.
 /// hdr5.set_slice_duration(2.5);
 /// assert_eq!(hdr1.get_slice_duration(), 2.5);
@@ -94,7 +94,7 @@ impl Default for NiftiHeader {
 }
 impl NiftiHeader {
     // Getter and setter methods.
-    // 
+    //
     // Signatures are for the larger types of NIFTI-2 fields.
     // When getting a smaller field from a NIFTI-1 header (e.g. intent_code) the
     // value is promoted to the larger type (e.g. i16 -> i32).
@@ -126,18 +126,16 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.dim_info = dim_info;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.dim_info = dim_info;
-            },
+            }
         }
     }
     /// Get data array dimensions.
     pub fn get_dim(&self) -> [u64; 8] {
         match *self {
-            Self::Nifti1Header(ref header) => {
-                header.dim.map(|x| x as u64)
-            },
+            Self::Nifti1Header(ref header) => header.dim.map(|x| x as u64),
             Self::Nifti2Header(ref header) => header.dim,
         }
     }
@@ -151,12 +149,12 @@ impl NiftiHeader {
                 for (&src, dst) in dim.iter().zip(&mut header.dim) {
                     *dst = TryInto::<i16>::try_into(src)? as u16;
                 }
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 for (&src, dst) in dim.iter().zip(&mut header.dim) {
                     *dst = TryInto::<i64>::try_into(src)? as u64;
                 }
-            },
+            }
         }
         Ok(())
     }
@@ -173,10 +171,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.intent_p1 = intent_p1 as f32;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.intent_p1 = intent_p1;
-            },
+            }
         }
     }
     /// Get 2nd intent parameter.
@@ -192,10 +190,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.intent_p2 = intent_p2 as f32;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.intent_p2 = intent_p2;
-            },
+            }
         }
     }
     /// Get 3rd intent parameter.
@@ -211,10 +209,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.intent_p3 = intent_p3 as f32;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.intent_p3 = intent_p3;
-            },
+            }
         }
     }
     /// Get NIFTI_INTENT_* code.
@@ -231,7 +229,7 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.intent_code = intent_code.try_into()?;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.intent_code = intent_code;
             }
@@ -250,10 +248,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.datatype = datatype;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.datatype = datatype;
-            },
+            }
         }
     }
     /// Get number of bits per voxel.
@@ -270,10 +268,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.bitpix = bitpix;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.bitpix = bitpix;
-            },
+            }
         }
         Ok(())
     }
@@ -291,10 +289,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.slice_start = TryInto::<i16>::try_into(slice_start)? as u16;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.slice_start = TryInto::<i64>::try_into(slice_start)? as u64;
-            },
+            }
         }
         Ok(())
     }
@@ -310,10 +308,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.pixdim = pixdim.map(|x| x as f32);
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.pixdim = *pixdim;
-            },
+            }
         }
     }
     /// Get offset into .nii file to reach the volume.  Note that NIFTI-1 stores
@@ -321,12 +319,10 @@ impl NiftiHeader {
     /// nearest integer.  Returns [`NiftiError::FieldSize`] if that integer
     /// would be negative.
     pub fn get_vox_offset(&self) -> Result<u64> {
-        Ok(
-            match *self {
-                Self::Nifti1Header(ref header) => (header.vox_offset.round() as i64).try_into()?,
-                Self::Nifti2Header(ref header) => header.vox_offset,
-            }
-        )
+        Ok(match *self {
+            Self::Nifti1Header(ref header) => (header.vox_offset.round() as i64).try_into()?,
+            Self::Nifti2Header(ref header) => header.vox_offset,
+        })
     }
     /// Set offset into .nii file to reach the volume.  Note that NIFTI-1 stores
     /// this offset as `f32` and NIFTI-2 stores it as `i64`.  Returns
@@ -336,10 +332,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.vox_offset = TryInto::<i32>::try_into(vox_offset)? as f32;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.vox_offset = TryInto::<i64>::try_into(vox_offset)? as u64;
-            },
+            }
         }
         Ok(())
     }
@@ -356,10 +352,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.scl_slope = scl_slope as f32;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.scl_slope = scl_slope;
-            },
+            }
         }
     }
     /// Get data scaling offset (intercept).  When the header version is
@@ -375,10 +371,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.scl_inter = scl_inter as f32;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.scl_inter = scl_inter;
-            },
+            }
         }
     }
     /// Get last slice index.
@@ -395,10 +391,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.slice_end = TryInto::<i16>::try_into(slice_end)? as u16;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.slice_end = TryInto::<i64>::try_into(slice_end)? as u64;
-            },
+            }
         }
         Ok(())
     }
@@ -415,10 +411,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.slice_code = slice_code.try_into()?;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.slice_code = slice_code;
-            },
+            }
         }
         Ok(())
     }
@@ -435,10 +431,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.xyzt_units = xyzt_units.try_into()?;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.xyzt_units = xyzt_units;
-            },
+            }
         }
         Ok(())
     }
@@ -455,10 +451,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.cal_max = cal_max as f32;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.cal_max = cal_max;
-            },
+            }
         }
     }
     /// Get min display intensity.
@@ -474,10 +470,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.cal_min = cal_min as f32;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.cal_min = cal_min;
-            },
+            }
         }
     }
     /// Get time for 1 slice (in seconds).
@@ -493,10 +489,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.slice_duration = slice_duration as f32;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.slice_duration = slice_duration;
-            },
+            }
         }
     }
     /// Get time axis shift.
@@ -511,10 +507,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.toffset = toffset as f32;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.toffset = toffset;
-            },
+            }
         }
     }
     /// Get description.
@@ -529,10 +525,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.descrip = descrip;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.descrip = descrip;
-            },
+            }
         }
     }
     /// Get auxiliary filename.
@@ -547,10 +543,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.aux_file = aux_file;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.aux_file = aux_file;
-            },
+            }
         }
     }
     /// Get NIFTI_XFORM_* code.
@@ -566,10 +562,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.qform_code = qform_code.try_into()?;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.qform_code = qform_code;
-            },
+            }
         }
         Ok(())
     }
@@ -586,10 +582,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.sform_code = sform_code.try_into()?;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.sform_code = sform_code;
-            },
+            }
         }
         Ok(())
     }
@@ -606,10 +602,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.quatern_b = quatern_b as f32;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.quatern_b = quatern_b;
-            },
+            }
         }
     }
     /// Get quaternion c param.
@@ -625,10 +621,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.quatern_c = quatern_c as f32;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.quatern_c = quatern_c;
-            },
+            }
         }
     }
     /// Get quaternion d param.
@@ -644,10 +640,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.quatern_d = quatern_d as f32;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.quatern_d = quatern_d;
-            },
+            }
         }
     }
     /// Get quaternion x param, also known as qoffset_x.
@@ -663,10 +659,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.quatern_x = quatern_x as f32;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.quatern_x = quatern_x;
-            },
+            }
         }
     }
     /// Get quaternion y param, also known as qoffset_y.
@@ -682,10 +678,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.quatern_y = quatern_y as f32;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.quatern_y = quatern_y;
-            },
+            }
         }
     }
     /// Get quaternion z param, also known as qoffset_z.
@@ -701,10 +697,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.quatern_z = quatern_z as f32;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.quatern_z = quatern_z;
-            },
+            }
         }
     }
     /// Get 1st row affine transform.
@@ -722,10 +718,10 @@ impl NiftiHeader {
                 for (&src, dst) in srow_x.iter().zip(&mut header.srow_x) {
                     *dst = src as f32;
                 }
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.srow_x = *srow_x;
-            },
+            }
         }
     }
     /// Get 2nd row affine transform.
@@ -743,10 +739,10 @@ impl NiftiHeader {
                 for (&src, dst) in srow_y.iter().zip(&mut header.srow_y) {
                     *dst = src as f32;
                 }
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.srow_y = *srow_y;
-            },
+            }
         }
     }
     /// Get 3rd row affine transform.
@@ -764,10 +760,10 @@ impl NiftiHeader {
                 for (&src, dst) in srow_z.iter().zip(&mut header.srow_z) {
                     *dst = src as f32;
                 }
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.srow_z = *srow_z;
-            },
+            }
         }
     }
     /// Get magic code.  This will be 4 bytes for a NIFTI-1 header and 8 bytes
@@ -791,10 +787,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.intent_name = intent_name;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.intent_name = intent_name;
-            },
+            }
         }
     }
     /// Get original data endianness.
@@ -810,10 +806,10 @@ impl NiftiHeader {
         match *self {
             Self::Nifti1Header(ref mut header) => {
                 header.endianness = endianness;
-            },
+            }
             Self::Nifti2Header(ref mut header) => {
                 header.endianness = endianness;
-            },
+            }
         }
     }
 
@@ -919,7 +915,7 @@ impl NiftiHeader {
                     endianness: header.endianness,
                     ..Default::default()
                 }
-            },
+            }
             Self::Nifti2Header(header) => header,
         }
     }
@@ -935,12 +931,13 @@ impl NiftiHeader {
     /// Initializes the unused data_type, db_name, extents, session_error,
     /// regular, glmax, and glmin fields with their default (zero) values.
     pub fn into_nifti1(self) -> Result<Nifti1Header> {
-        Ok( match self {
+        Ok(match self {
             Self::Nifti1Header(header) => header,
             Self::Nifti2Header(header) => {
                 Nifti1Header {
                     dim_info: header.dim_info,
-                    dim: { // attempt to map u64 to u16 that fits in an i16
+                    dim: {
+                        // attempt to map u64 to u16 that fits in an i16
                         let mut dim: [u16; 8] = [0; 8];
                         for (&src, dst) in header.dim.iter().zip(&mut dim) {
                             *dst = TryInto::<i16>::try_into(src)? as u16;
@@ -991,8 +988,8 @@ impl NiftiHeader {
                     endianness: header.endianness,
                     ..Default::default()
                 }
-            },
-        } )
+            }
+        })
     }
 
     /// Fix some commonly invalid fields.
@@ -1032,8 +1029,10 @@ impl NiftiHeader {
 
     /// Get the data type as a validated enum.
     pub fn data_type(&self) -> Result<NiftiType> {
-        FromPrimitive::from_i16(self.get_datatype())
-            .ok_or(NiftiError::InvalidCode("datatype", self.get_datatype().into()))
+        FromPrimitive::from_i16(self.get_datatype()).ok_or(NiftiError::InvalidCode(
+            "datatype",
+            self.get_datatype().into(),
+        ))
     }
 
     /// Get the spatial units type as a validated unit enum.
@@ -1057,8 +1056,10 @@ impl NiftiHeader {
 
     /// Get the slice order as a validated enum.
     pub fn slice_order(&self) -> Result<SliceOrder> {
-        FromPrimitive::from_i32(self.get_slice_code())
-            .ok_or(NiftiError::InvalidCode("slice order", self.get_slice_code()))
+        FromPrimitive::from_i32(self.get_slice_code()).ok_or(NiftiError::InvalidCode(
+            "slice order",
+            self.get_slice_code(),
+        ))
     }
 
     /// Get the intent as a validated enum.
@@ -1119,14 +1120,14 @@ impl NiftiHeader {
 }
 
 /// The NIFTI-1 header data type.
-/// 
+///
 /// All fields are public and named after the specification's header file.
 /// The type of each field was adjusted according to their use and
 /// array limitations.
-/// 
+///
 /// See also `NiftiHeader` for a high-level abstraction over NIFTI-1 and NIFTI-2
 /// headers.
-/// 
+///
 /// # Examples
 ///
 /// ```
@@ -1242,14 +1243,14 @@ pub struct Nifti1Header {
 }
 
 /// The NIFTI-2 header data type.
-/// 
+///
 /// All fields are public and named after the specification's header file.
 /// The type of each field was adjusted according to their use and
 /// array limitations.
-/// 
+///
 /// See also `NiftiHeader` for a high-level abstraction over NIFTI-1 and NIFTI-2
 /// headers.
-/// 
+///
 /// # Examples
 ///
 /// ```
@@ -1522,11 +1523,7 @@ impl NiftiHeader {
 
         let quaternion = self.qform_quaternion();
         let r = quaternion_to_affine(quaternion);
-        let s = Matrix3::from_diagonal(&Vector3::new(
-            pixdim[1],
-            pixdim[2],
-            pixdim[3] * pixdim[0],
-        ));
+        let s = Matrix3::from_diagonal(&Vector3::new(pixdim[1], pixdim[2], pixdim[3] * pixdim[0]));
         let m = r * s;
         #[rustfmt::skip]
         let affine = Matrix4::new(

--- a/src/header.rs
+++ b/src/header.rs
@@ -206,7 +206,7 @@ impl Default for NiftiHeader {
 
             intent_name: [0; 16],
 
-            magic: *MAGIC_CODE_NI1,
+            magic: *MAGIC_CODE_NIP1,
 
             endianness: Endianness::native(),
         }

--- a/src/header.rs
+++ b/src/header.rs
@@ -76,7 +76,7 @@ pub const MAGIC_CODE_NIP2: &[u8; 8] = b"n+2\0\r\n\x1A\n";
 ///
 /// // Change the slice duration to two-and-a-half seconds.
 /// hdr5.set_slice_duration(2.5);
-/// assert_eq!(hdr1.get_slice_duration(), 2.5);
+/// assert_eq!(hdr1.slice_duration(), 2.5);
 /// # Ok(())
 /// # }
 /// ```
@@ -108,14 +108,14 @@ impl NiftiHeader {
     /// Header size, must be 348 for a NIFTI-1 header and 540 for NIFTI-2.
     /// There is no corresponding `set_sizeof_hdr()` because you should never
     /// need to set this field manually.
-    pub fn get_sizeof_hdr(&self) -> u32 {
+    pub fn sizeof_hdr(&self) -> u32 {
         match *self {
             Self::Nifti1Header(ref header) => header.sizeof_hdr,
             Self::Nifti2Header(ref header) => header.sizeof_hdr,
         }
     }
     /// Get MRI slice ordering.
-    pub fn get_dim_info(&self) -> u8 {
+    pub fn dim_info(&self) -> u8 {
         match *self {
             Self::Nifti1Header(ref header) => header.dim_info,
             Self::Nifti2Header(ref header) => header.dim_info,
@@ -133,7 +133,7 @@ impl NiftiHeader {
         }
     }
     /// Get data array dimensions.
-    pub fn get_dim(&self) -> [u64; 8] {
+    pub fn raw_dim(&self) -> [u64; 8] {
         match *self {
             Self::Nifti1Header(ref header) => header.dim.map(|x| x as u64),
             Self::Nifti2Header(ref header) => header.dim,
@@ -159,7 +159,7 @@ impl NiftiHeader {
         Ok(())
     }
     /// Get 1st intent parameter.
-    pub fn get_intent_p1(&self) -> f64 {
+    pub fn intent_p1(&self) -> f64 {
         match *self {
             Self::Nifti1Header(ref header) => header.intent_p1 as f64,
             Self::Nifti2Header(ref header) => header.intent_p1,
@@ -178,7 +178,7 @@ impl NiftiHeader {
         }
     }
     /// Get 2nd intent parameter.
-    pub fn get_intent_p2(&self) -> f64 {
+    pub fn intent_p2(&self) -> f64 {
         match *self {
             Self::Nifti1Header(ref header) => header.intent_p2 as f64,
             Self::Nifti2Header(ref header) => header.intent_p2,
@@ -197,7 +197,7 @@ impl NiftiHeader {
         }
     }
     /// Get 3rd intent parameter.
-    pub fn get_intent_p3(&self) -> f64 {
+    pub fn intent_p3(&self) -> f64 {
         match *self {
             Self::Nifti1Header(ref header) => header.intent_p3 as f64,
             Self::Nifti2Header(ref header) => header.intent_p3,
@@ -216,7 +216,7 @@ impl NiftiHeader {
         }
     }
     /// Get NIFTI_INTENT_* code.
-    pub fn get_intent_code(&self) -> i32 {
+    pub fn intent_code(&self) -> i32 {
         match *self {
             Self::Nifti1Header(ref header) => header.intent_code as i32,
             Self::Nifti2Header(ref header) => header.intent_code,
@@ -237,7 +237,7 @@ impl NiftiHeader {
         Ok(())
     }
     /// Get the data type.
-    pub fn get_datatype(&self) -> i16 {
+    pub fn datatype(&self) -> i16 {
         match *self {
             Self::Nifti1Header(ref header) => header.datatype,
             Self::Nifti2Header(ref header) => header.datatype,
@@ -255,7 +255,7 @@ impl NiftiHeader {
         }
     }
     /// Get number of bits per voxel.
-    pub fn get_bitpix(&self) -> u16 {
+    pub fn bitpix(&self) -> u16 {
         match *self {
             Self::Nifti1Header(ref header) => header.bitpix,
             Self::Nifti2Header(ref header) => header.bitpix,
@@ -276,7 +276,7 @@ impl NiftiHeader {
         Ok(())
     }
     /// Get first slice index.
-    pub fn get_slice_start(&self) -> u64 {
+    pub fn slice_start(&self) -> u64 {
         match *self {
             Self::Nifti1Header(ref header) => header.slice_start as u64,
             Self::Nifti2Header(ref header) => header.slice_start,
@@ -297,7 +297,7 @@ impl NiftiHeader {
         Ok(())
     }
     /// Get grid spacings.
-    pub fn get_pixdim(&self) -> [f64; 8] {
+    pub fn pixdim(&self) -> [f64; 8] {
         match *self {
             Self::Nifti1Header(ref header) => header.pixdim.map(|x| x as f64),
             Self::Nifti2Header(ref header) => header.pixdim,
@@ -318,7 +318,7 @@ impl NiftiHeader {
     /// this offset as `f32`.  Floating point values will be rounded to the
     /// nearest integer.  Returns [`NiftiError::FieldSize`] if that integer
     /// would be negative.
-    pub fn get_vox_offset(&self) -> Result<u64> {
+    pub fn vox_offset(&self) -> Result<u64> {
         Ok(match *self {
             Self::Nifti1Header(ref header) => (header.vox_offset.round() as i64).try_into()?,
             Self::Nifti2Header(ref header) => header.vox_offset,
@@ -340,7 +340,7 @@ impl NiftiHeader {
         Ok(())
     }
     /// Get data scaling slope.
-    pub fn get_scl_slope(&self) -> f64 {
+    pub fn scl_slope(&self) -> f64 {
         match *self {
             Self::Nifti1Header(ref header) => header.scl_slope as f64,
             Self::Nifti2Header(ref header) => header.scl_slope,
@@ -360,7 +360,7 @@ impl NiftiHeader {
     }
     /// Get data scaling offset (intercept).  When the header version is
     /// NIFTI-1, precision is reduced to `f32`.
-    pub fn get_scl_inter(&self) -> f64 {
+    pub fn scl_inter(&self) -> f64 {
         match *self {
             Self::Nifti1Header(ref header) => header.scl_inter as f64,
             Self::Nifti2Header(ref header) => header.scl_inter,
@@ -378,7 +378,7 @@ impl NiftiHeader {
         }
     }
     /// Get last slice index.
-    pub fn get_slice_end(&self) -> u64 {
+    pub fn slice_end(&self) -> u64 {
         match *self {
             Self::Nifti1Header(ref header) => header.slice_end as u64,
             Self::Nifti2Header(ref header) => header.slice_end,
@@ -399,7 +399,7 @@ impl NiftiHeader {
         Ok(())
     }
     /// Get slice timing order.
-    pub fn get_slice_code(&self) -> i32 {
+    pub fn slice_code(&self) -> i32 {
         match *self {
             Self::Nifti1Header(ref header) => header.slice_code as i32,
             Self::Nifti2Header(ref header) => header.slice_code,
@@ -419,7 +419,7 @@ impl NiftiHeader {
         Ok(())
     }
     /// Get units of `pixdim[1..4]`.
-    pub fn get_xyzt_units(&self) -> i32 {
+    pub fn raw_xyzt_units(&self) -> i32 {
         match *self {
             Self::Nifti1Header(ref header) => header.xyzt_units as i32,
             Self::Nifti2Header(ref header) => header.xyzt_units,
@@ -439,7 +439,7 @@ impl NiftiHeader {
         Ok(())
     }
     /// Get max display intensity.
-    pub fn get_cal_max(&self) -> f64 {
+    pub fn cal_max(&self) -> f64 {
         match *self {
             Self::Nifti1Header(ref header) => header.cal_max as f64,
             Self::Nifti2Header(ref header) => header.cal_max,
@@ -458,7 +458,7 @@ impl NiftiHeader {
         }
     }
     /// Get min display intensity.
-    pub fn get_cal_min(&self) -> f64 {
+    pub fn cal_min(&self) -> f64 {
         match *self {
             Self::Nifti1Header(ref header) => header.cal_min as f64,
             Self::Nifti2Header(ref header) => header.cal_min,
@@ -477,7 +477,7 @@ impl NiftiHeader {
         }
     }
     /// Get time for 1 slice (in seconds).
-    pub fn get_slice_duration(&self) -> f64 {
+    pub fn slice_duration(&self) -> f64 {
         match *self {
             Self::Nifti1Header(ref header) => header.slice_duration as f64,
             Self::Nifti2Header(ref header) => header.slice_duration,
@@ -496,7 +496,7 @@ impl NiftiHeader {
         }
     }
     /// Get time axis shift.
-    pub fn get_toffset(&self) -> f64 {
+    pub fn toffset(&self) -> f64 {
         match *self {
             Self::Nifti1Header(ref header) => header.toffset as f64,
             Self::Nifti2Header(ref header) => header.toffset,
@@ -514,7 +514,7 @@ impl NiftiHeader {
         }
     }
     /// Get description.
-    pub fn get_descrip(&self) -> &[u8; 80] {
+    pub fn descrip(&self) -> &[u8; 80] {
         match *self {
             Self::Nifti1Header(ref header) => &header.descrip,
             Self::Nifti2Header(ref header) => &header.descrip,
@@ -532,7 +532,7 @@ impl NiftiHeader {
         }
     }
     /// Get auxiliary filename.
-    pub fn get_aux_file(&self) -> &[u8; 24] {
+    pub fn aux_file(&self) -> &[u8; 24] {
         match *self {
             Self::Nifti1Header(ref header) => &header.aux_file,
             Self::Nifti2Header(ref header) => &header.aux_file,
@@ -550,7 +550,7 @@ impl NiftiHeader {
         }
     }
     /// Get NIFTI_XFORM_* code.
-    pub fn get_qform_code(&self) -> i32 {
+    pub fn qform_code(&self) -> i32 {
         match *self {
             Self::Nifti1Header(ref header) => header.qform_code as i32,
             Self::Nifti2Header(ref header) => header.qform_code,
@@ -570,7 +570,7 @@ impl NiftiHeader {
         Ok(())
     }
     /// Get NIFTI_XFORM_* code.
-    pub fn get_sform_code(&self) -> i32 {
+    pub fn sform_code(&self) -> i32 {
         match *self {
             Self::Nifti1Header(ref header) => header.sform_code as i32,
             Self::Nifti2Header(ref header) => header.sform_code,
@@ -590,7 +590,7 @@ impl NiftiHeader {
         Ok(())
     }
     /// Get quaternion b param.
-    pub fn get_quatern_b(&self) -> f64 {
+    pub fn quatern_b(&self) -> f64 {
         match *self {
             Self::Nifti1Header(ref header) => header.quatern_b as f64,
             Self::Nifti2Header(ref header) => header.quatern_b,
@@ -609,7 +609,7 @@ impl NiftiHeader {
         }
     }
     /// Get quaternion c param.
-    pub fn get_quatern_c(&self) -> f64 {
+    pub fn quatern_c(&self) -> f64 {
         match *self {
             Self::Nifti1Header(ref header) => header.quatern_c as f64,
             Self::Nifti2Header(ref header) => header.quatern_c,
@@ -628,7 +628,7 @@ impl NiftiHeader {
         }
     }
     /// Get quaternion d param.
-    pub fn get_quatern_d(&self) -> f64 {
+    pub fn quatern_d(&self) -> f64 {
         match *self {
             Self::Nifti1Header(ref header) => header.quatern_d as f64,
             Self::Nifti2Header(ref header) => header.quatern_d,
@@ -647,7 +647,7 @@ impl NiftiHeader {
         }
     }
     /// Get quaternion x param, also known as qoffset_x.
-    pub fn get_quatern_x(&self) -> f64 {
+    pub fn quatern_x(&self) -> f64 {
         match *self {
             Self::Nifti1Header(ref header) => header.quatern_x as f64,
             Self::Nifti2Header(ref header) => header.quatern_x,
@@ -666,7 +666,7 @@ impl NiftiHeader {
         }
     }
     /// Get quaternion y param, also known as qoffset_y.
-    pub fn get_quatern_y(&self) -> f64 {
+    pub fn quatern_y(&self) -> f64 {
         match *self {
             Self::Nifti1Header(ref header) => header.quatern_y as f64,
             Self::Nifti2Header(ref header) => header.quatern_y,
@@ -685,7 +685,7 @@ impl NiftiHeader {
         }
     }
     /// Get quaternion z param, also known as qoffset_z.
-    pub fn get_quatern_z(&self) -> f64 {
+    pub fn quatern_z(&self) -> f64 {
         match *self {
             Self::Nifti1Header(ref header) => header.quatern_z as f64,
             Self::Nifti2Header(ref header) => header.quatern_z,
@@ -704,7 +704,7 @@ impl NiftiHeader {
         }
     }
     /// Get 1st row affine transform.
-    pub fn get_srow_x(&self) -> [f64; 4] {
+    pub fn srow_x(&self) -> [f64; 4] {
         match *self {
             Self::Nifti1Header(ref header) => header.srow_x.map(|x| x as f64),
             Self::Nifti2Header(ref header) => header.srow_x,
@@ -725,7 +725,7 @@ impl NiftiHeader {
         }
     }
     /// Get 2nd row affine transform.
-    pub fn get_srow_y(&self) -> [f64; 4] {
+    pub fn srow_y(&self) -> [f64; 4] {
         match *self {
             Self::Nifti1Header(ref header) => header.srow_y.map(|x| x as f64),
             Self::Nifti2Header(ref header) => header.srow_y,
@@ -746,7 +746,7 @@ impl NiftiHeader {
         }
     }
     /// Get 3rd row affine transform.
-    pub fn get_srow_z(&self) -> [f64; 4] {
+    pub fn srow_z(&self) -> [f64; 4] {
         match *self {
             Self::Nifti1Header(ref header) => header.srow_z.map(|x| x as f64),
             Self::Nifti2Header(ref header) => header.srow_z,
@@ -769,14 +769,14 @@ impl NiftiHeader {
     /// Get magic code.  This will be 4 bytes for a NIFTI-1 header and 8 bytes
     /// for a NIFTI-2 header.  There is no corresponding `set_magic()` because
     /// you should never need to set this field manually.
-    pub fn get_magic(&self) -> &[u8] {
+    pub fn magic(&self) -> &[u8] {
         match *self {
             Self::Nifti1Header(ref header) => &header.magic,
             Self::Nifti2Header(ref header) => &header.magic,
         }
     }
     /// Get 'name' or meaning of data.
-    pub fn get_intent_name(&self) -> &[u8; 16] {
+    pub fn intent_name(&self) -> &[u8; 16] {
         match *self {
             Self::Nifti1Header(ref header) => &header.intent_name,
             Self::Nifti2Header(ref header) => &header.intent_name,
@@ -794,7 +794,7 @@ impl NiftiHeader {
         }
     }
     /// Get original data endianness.
-    pub fn get_endianness(&self) -> Endianness {
+    pub fn endianness(&self) -> Endianness {
         match *self {
             Self::Nifti1Header(ref header) => header.endianness,
             Self::Nifti2Header(ref header) => header.endianness,
@@ -862,7 +862,7 @@ impl NiftiHeader {
     /// Currently, only the following problems are fixed:
     /// - If `pixdim[0]` isn't equal to -1.0 or 1.0, it will be set to 1.0
     pub fn fix(&mut self) {
-        let mut pixdim = self.get_pixdim();
+        let mut pixdim = self.pixdim();
         if !self.is_pixdim_0_valid() {
             pixdim[0] = 1.;
             self.set_pixdim(&pixdim);
@@ -878,7 +878,7 @@ impl NiftiHeader {
     /// `NiftiError::InconsistentDim` if `dim[0]` does not represent a valid
     /// dimensionality, or any of the real dimensions are zero.
     pub fn dim(&self) -> Result<Vec<u64>> {
-        Ok(validate_dim(&self.get_dim())?.to_vec())
+        Ok(validate_dim(&self.raw_dim())?.to_vec())
     }
 
     /// Retrieve and validate the number of dimensions of the volume. This is
@@ -889,27 +889,27 @@ impl NiftiHeader {
     /// `NiftiError::` if `dim[0]` does not represent a valid dimensionality
     /// (it must be positive and not higher than 7).
     pub fn dimensionality(&self) -> Result<usize> {
-        validate_dimensionality(&self.get_dim())
+        validate_dimensionality(&self.raw_dim())
     }
 
     /// Get the data type as a validated enum.
     pub fn data_type(&self) -> Result<NiftiType> {
-        FromPrimitive::from_i16(self.get_datatype()).ok_or(NiftiError::InvalidCode(
+        FromPrimitive::from_i16(self.datatype()).ok_or(NiftiError::InvalidCode(
             "datatype",
-            self.get_datatype().into(),
+            self.datatype().into(),
         ))
     }
 
     /// Get the spatial units type as a validated unit enum.
     pub fn xyzt_to_space(&self) -> Result<Unit> {
-        let space_code = self.get_xyzt_units() & 0o0007;
+        let space_code = self.raw_xyzt_units() & 0o0007;
         FromPrimitive::from_i32(space_code)
             .ok_or(NiftiError::InvalidCode("xyzt units (space)", space_code))
     }
 
     /// Get the time units type as a validated unit enum.
     pub fn xyzt_to_time(&self) -> Result<Unit> {
-        let time_code = self.get_xyzt_units() & 0o0070;
+        let time_code = self.raw_xyzt_units() & 0o0070;
         FromPrimitive::from_i32(time_code)
             .ok_or(NiftiError::InvalidCode("xyzt units (time)", time_code))
     }
@@ -921,28 +921,28 @@ impl NiftiHeader {
 
     /// Get the slice order as a validated enum.
     pub fn slice_order(&self) -> Result<SliceOrder> {
-        FromPrimitive::from_i32(self.get_slice_code()).ok_or(NiftiError::InvalidCode(
+        FromPrimitive::from_i32(self.slice_code()).ok_or(NiftiError::InvalidCode(
             "slice order",
-            self.get_slice_code(),
+            self.slice_code(),
         ))
     }
 
     /// Get the intent as a validated enum.
     pub fn intent(&self) -> Result<Intent> {
-        FromPrimitive::from_i32(self.get_intent_code())
-            .ok_or(NiftiError::InvalidCode("intent", self.get_intent_code()))
+        FromPrimitive::from_i32(self.intent_code())
+            .ok_or(NiftiError::InvalidCode("intent", self.intent_code()))
     }
 
     /// Get the qform coordinate mapping method as a validated enum.
     pub fn qform(&self) -> Result<XForm> {
-        FromPrimitive::from_i32(self.get_qform_code())
-            .ok_or(NiftiError::InvalidCode("qform", self.get_qform_code()))
+        FromPrimitive::from_i32(self.qform_code())
+            .ok_or(NiftiError::InvalidCode("qform", self.qform_code()))
     }
 
     /// Get the sform coordinate mapping method as a validated enum.
     pub fn sform(&self) -> Result<XForm> {
-        FromPrimitive::from_i32(self.get_sform_code())
-            .ok_or(NiftiError::InvalidCode("sform", self.get_sform_code()))
+        FromPrimitive::from_i32(self.sform_code())
+            .ok_or(NiftiError::InvalidCode("sform", self.sform_code()))
     }
 
     /// Safely set the `descrip` field using a buffer.
@@ -980,7 +980,7 @@ impl NiftiHeader {
     /// Check whether `pixdim[0]` is either -1 or 1.
     #[inline]
     fn is_pixdim_0_valid(&self) -> bool {
-        (self.get_pixdim()[0].abs() - 1.).abs() < 1e-11
+        (self.pixdim()[0].abs() - 1.).abs() < 1e-11
     }
 }
 
@@ -1486,9 +1486,9 @@ impl NiftiHeader {
         T: RealField,
         f64: SubsetOf<T>,
     {
-        if self.get_sform_code() != 0 {
+        if self.sform_code() != 0 {
             self.sform_affine::<T>()
-        } else if self.get_qform_code() != 0 {
+        } else if self.qform_code() != 0 {
             self.qform_affine::<T>()
         } else {
             self.base_affine::<T>()
@@ -1501,9 +1501,9 @@ impl NiftiHeader {
         T: RealField,
         f64: SubsetOf<T>,
     {
-        let srow_x = self.get_srow_x();
-        let srow_y = self.get_srow_y();
-        let srow_z = self.get_srow_z();
+        let srow_x = self.srow_x();
+        let srow_y = self.srow_y();
+        let srow_z = self.srow_z();
         #[rustfmt::skip]
         let affine = Matrix4::new(
             srow_x[0], srow_x[1], srow_x[2], srow_x[3],
@@ -1519,7 +1519,7 @@ impl NiftiHeader {
     where
         T: RealField,
     {
-        let pixdim = self.get_pixdim();
+        let pixdim = self.pixdim();
         if pixdim[1] < 0.0 || pixdim[2] < 0.0 || pixdim[3] < 0.0 {
             panic!("All spacings (pixdim) should be positive");
         }
@@ -1533,9 +1533,9 @@ impl NiftiHeader {
         let m = r * s;
         #[rustfmt::skip]
         let affine = Matrix4::new(
-            m[0], m[3], m[6], self.get_quatern_x(),
-            m[1], m[4], m[7], self.get_quatern_y(),
-            m[2], m[5], m[8], self.get_quatern_z(),
+            m[0], m[3], m[6], self.quatern_x(),
+            m[1], m[4], m[7], self.quatern_y(),
+            m[2], m[5], m[8], self.quatern_z(),
             0.0, 0.0, 0.0, 1.0,
         );
         nalgebra::convert(affine)
@@ -1548,9 +1548,9 @@ impl NiftiHeader {
     where
         T: RealField,
     {
-        let dim = self.get_dim();
+        let dim = self.raw_dim();
         let d = dim[0] as usize;
-        let affine = shape_zoom_affine(&dim[1..d + 1], &self.get_pixdim()[1..d + 1]);
+        let affine = shape_zoom_affine(&dim[1..d + 1], &self.pixdim()[1..d + 1]);
         nalgebra::convert(affine)
     }
 
@@ -1559,9 +1559,9 @@ impl NiftiHeader {
     /// Fills a value by assuming this is a unit quaternion.
     fn qform_quaternion(&self) -> Quaternion<f64> {
         let xyz = Vector3::new(
-            self.get_quatern_b(),
-            self.get_quatern_c(),
-            self.get_quatern_d(),
+            self.quatern_b(),
+            self.quatern_c(),
+            self.quatern_d(),
         );
         fill_positive(xyz)
     }
@@ -1663,7 +1663,7 @@ impl NiftiHeader {
         let quaternion = affine_to_quaternion(&pr);
 
         self.set_qform_code(code as i32).unwrap();
-        let mut pixdim = self.get_pixdim();
+        let mut pixdim = self.pixdim();
         pixdim[0] = qfac;
         pixdim[1] = spacing.0;
         pixdim[2] = spacing.1;

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,5 +1,5 @@
 //! This module defines the `NiftiHeader` struct, which is used
-//! to provide important information about NIFTI-1 volumes.
+//! to provide important information about NIFTI volumes.
 
 #[cfg(feature = "nalgebra_affine")]
 use crate::affine::*;
@@ -15,6 +15,7 @@ use num_traits::FromPrimitive;
 use num_traits::ToPrimitive;
 #[cfg(feature = "nalgebra_affine")]
 use simba::scalar::SubsetOf;
+use std::convert::TryInto;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::ops::Deref;
@@ -29,24 +30,202 @@ pub const MAGIC_CODE_NI2: &[u8; 8] = b"ni2\0\r\n\x1A\n";
 /// Magic code for full NIFTI-1 files (extention ".nii[.gz]").
 pub const MAGIC_CODE_NIP2: &[u8; 8] = b"n+2\0\r\n\x1A\n";
 
-/// The NIFTI-1 header data type.
-/// All fields are public and named after the specification's header file.
-/// The type of each field was adjusted according to their use and
-/// array limitations.
-///
+/// Abstraction over NIFTI version 1 and 2 headers.  This is the high-level type
+/// you will likely use most often.
+/// 
+/// The NIFTI file format has two different versions for headers.  NIFTI-1 was
+/// finalized in 2007 and is still widely used by many scanner manufacturers.
+/// NIFTI-2 was created in 2011 and is widely used in many research-oriented
+/// neuroimaging data sets.  NIFTI-2 is almost identical to NIFTI-1 except for
+/// using larger data types (e.g. 64-bit floating point types instead of 32-bit)
+/// and removal of some unused fields.  Refer to the
+/// [reference documentation](https://nifti.nimh.nih.gov/pub/dist/doc/nifti2.h)
+/// for a comprehensive list of changes.
+/// 
+/// For practical purposes, there is no difference between the header versions.
+/// This `NiftiHeader` type is an `enum` storing either a `Nifti2Header` or
+/// `Nifti1Header`.  Calling `from_file()` or `from_reader()` automatically
+/// selects the correct variant depending on the version in the input file.
+/// Getter and setter methods like `get_slice_duration()` and
+/// `set_slice_duration()`, and high-level methods like `data_type()`,
+/// automatically convert values to/from the appropriate underlying type
+/// depending on the header version.
+/// 
+/// If you must work with a specific header version, you can easily convert
+/// between versions with `into_nifti1()` or `into_nifti2()`.
+/// 
 /// # Examples
 ///
 /// ```no_run
-/// use nifti::{NiftiHeader, Endianness};
+/// use nifti::{NiftiHeader, NiftiType};
 /// # use nifti::Result;
 ///
 /// # fn run() -> Result<()> {
+/// // Read a header from a file.
 /// let hdr1 = NiftiHeader::from_file("0000.hdr")?;
 /// let hdr2 = NiftiHeader::from_file("0001.hdr.gz")?;
 /// let hdr3 = NiftiHeader::from_file("4321.nii.gz")?;
+/// 
+/// // Convert a header into NIFTI-2 (does nothing if already NIFTI-2).
+/// // First extracts/converts the `NiftiHeader` into a `Nifti2Header` and then
+/// // puts it back into a `NiftiHeader`.
+/// let hdr4 = hdr3.into_nifti2().into_nifti();
+/// 
+/// // Make a new header from scratch.  Defaults to NIFTI-2.
+/// let mut hdr5 = NiftiHeader::default();
+/// 
+/// // Change the slice duration to two-and-a-half seconds.
+/// hdr5.set_slice_duration(2.5);
+/// assert_eq!(hdr1.get_slice_duration(), 2.5);
 /// # Ok(())
 /// # }
 /// ```
+#[derive(Debug, Clone, PartialEq)]
+pub enum NiftiHeader {
+    /// The underlying header version is `NIFTI-1`.
+    Nifti1Header(Nifti1Header),
+    /// The underlying header version is `NIFTI-2`.
+    Nifti2Header(Nifti2Header),
+}
+impl Default for NiftiHeader {
+    fn default() -> NiftiHeader {
+        Nifti2Header::default().into_nifti() // default to NIfTI-2 format
+    }
+}
+impl NiftiHeader {
+    /// Convert this header into a NIFTI-2 header.
+    /// Does nothing if the header is already NIFTI-2.
+    /// Promotes NIFTI-1 fields to larger types and removes unused fields.
+    /// Increases header size from NIFTI-1's 348 to NIFTI-2's 540 bytes.
+    /// Moves vox_offset forward by corresponding 192 bytes.
+    /// Changes NIFTI-1 magic string to NIFTI-2 magic string.
+    pub fn into_nifti2(self) -> Nifti2Header {
+        match self {
+            Self::Nifti1Header(header) => {
+                Nifti2Header {
+                    // If the original header file uses the NIFTI-1 magic string
+                    // for .hdr/.img then the new header should use the NIFTI-2
+                    // magic string for this filetype, otherwise use the magic
+                    // string for .nii.
+                    magic: if &header.magic == MAGIC_CODE_NI1 {
+                        *MAGIC_CODE_NI2
+                    } else {
+                        *MAGIC_CODE_NIP2
+                    },
+                    datatype: header.datatype,
+                    bitpix: header.bitpix,
+                    dim: header.dim.map(|x| x as u64),
+                    intent_p1: header.intent_p1 as f64,
+                    intent_p2: header.intent_p2 as f64,
+                    intent_p3: header.intent_p3 as f64,
+                    pixdim: header.pixdim.map(|x| x as f64),
+                    // Voxel offset should be equal to previous voxel offset
+                    // plus difference in header size = 540 - 348 = 192.
+                    vox_offset: header.vox_offset.round() as u64 + 192,
+                    scl_slope: header.scl_slope as f64,
+                    scl_inter: header.scl_inter as f64,
+                    cal_max: header.cal_max as f64,
+                    cal_min: header.cal_min as f64,
+                    slice_duration: header.slice_duration as f64,
+                    toffset: header.toffset as f64,
+                    slice_start: header.slice_start as u64,
+                    slice_end: header.slice_end as u64,
+                    descrip: header.descrip,
+                    aux_file: header.aux_file,
+                    qform_code: header.qform_code as i32,
+                    sform_code: header.sform_code as i32,
+                    quatern_b: header.quatern_b as f64,
+                    quatern_c: header.quatern_c as f64,
+                    quatern_d: header.quatern_d as f64,
+                    quatern_x: header.quatern_x as f64,
+                    quatern_y: header.quatern_y as f64,
+                    quatern_z: header.quatern_z as f64,
+                    srow_x: header.srow_x.map(|x| x as f64),
+                    srow_y: header.srow_y.map(|x| x as f64),
+                    srow_z: header.srow_z.map(|x| x as f64),
+                    slice_code: header.slice_code as i32,
+                    xyzt_units: header.xyzt_units as i32,
+                    intent_code: header.intent_code as i32,
+                    intent_name: header.intent_name,
+                    dim_info: header.dim_info,
+                    endianness: header.endianness,
+                    ..Default::default()
+                }
+            },
+            Self::Nifti2Header(header) => header,
+        }
+    }
+
+    /// Convert this header into a NIFTI-1 header.
+    /// Does nothing if the header is already NIFTI-1.
+    /// Shrinks the NIFTI-2 header size from 540 to NIFTI-1's 348, and moves
+    /// vox_offset back by a corresponding 192 bytes.
+    /// Attempts to downcast NIFTI-2 fields to their smaller NIFTI-1 types.
+    /// Performs saturating downcast for floating point fields.
+    /// Performs fallible downcast for integer fields, returning
+    /// [`NiftiError::FieldSize`] if the field won't fit into the smaller type.
+    /// Initializes the unused data_type, db_name, extents, session_error,
+    /// regular, glmax, and glmin fields with their default (zero) values.
+    pub fn into_nifti1(self) -> Result<Nifti1Header> {
+        Ok( match self {
+            Self::Nifti1Header(header) => header,
+            Self::Nifti2Header(header) => {
+                Nifti1Header {
+                    dim_info: header.dim_info,
+                    dim: { // attempt to map u64 to u16 that fits in an i16
+                        let mut dim: [u16; 8] = [0; 8];
+                        for (&src, dst) in header.dim.iter().zip(&mut dim) {
+                            *dst = TryInto::<i16>::try_into(src)? as u16;
+                        }
+                        dim
+                    },
+                    intent_p1: header.intent_p1 as f32,
+                    intent_p2: header.intent_p2 as f32,
+                    intent_p3: header.intent_p3 as f32,
+                    intent_code: header.intent_code.try_into()?,
+                    datatype: header.datatype,
+                    bitpix: header.bitpix,
+                    slice_start: TryInto::<i16>::try_into(header.slice_start)? as u16,
+                    pixdim: header.pixdim.map(|x| x as f32),
+                    vox_offset: TryInto::<i32>::try_into(header.vox_offset)? as f32,
+                    scl_slope: header.scl_slope as f32,
+                    scl_inter: header.scl_inter as f32,
+                    slice_end: TryInto::<i16>::try_into(header.slice_end)? as u16,
+                    slice_code: header.slice_code.try_into()?,
+                    xyzt_units: header.xyzt_units.try_into()?,
+                    cal_max: header.cal_max as f32,
+                    cal_min: header.cal_min as f32,
+                    slice_duration: header.slice_duration as f32,
+                    toffset: header.toffset as f32,
+                    descrip: header.descrip,
+                    aux_file: header.aux_file,
+                    qform_code: header.qform_code.try_into()?,
+                    sform_code: header.sform_code.try_into()?,
+                    quatern_b: header.quatern_b as f32,
+                    quatern_c: header.quatern_c as f32,
+                    quatern_d: header.quatern_d as f32,
+                    quatern_x: header.quatern_x as f32,
+                    quatern_y: header.quatern_y as f32,
+                    quatern_z: header.quatern_z as f32,
+                    srow_x: header.srow_x.map(|x| x as f32),
+                    srow_y: header.srow_y.map(|x| x as f32),
+                    srow_z: header.srow_z.map(|x| x as f32),
+                    intent_name: header.intent_name,
+                    // If the original header file uses the NIFTI-1 magic string
+                    // for .hdr/.img then the new header should use the NIFTI-2
+                    // magic string for this filetype, otherwise use the magic
+                    // string for .nii.
+                    magic: if &header.magic == MAGIC_CODE_NI2 {
+                        *MAGIC_CODE_NI1
+                    } else {
+                        *MAGIC_CODE_NIP1
+                    },
+                    endianness: header.endianness,
+                    ..Default::default()
+                }
+            },
+        } )
+    }
 /// The NIFTI-1 header data type.
 /// 
 /// All fields are public and named after the specification's header file.
@@ -379,22 +558,17 @@ impl Default for Nifti2Header {
     }
 }
 
-    /// Retrieve and validate the number of dimensions of the volume. This is
-    /// `dim[0]` after the necessary byte order conversions.
-    ///
-    /// # Error
-    ///
-    /// `NiftiError::` if `dim[0]` does not represent a valid dimensionality
-    /// (it must be positive and not higher than 7).
-    pub fn dimensionality(&self) -> Result<usize> {
-        validate_dimensionality(&self.dim)
+impl Nifti1Header {
+    /// Place this `Nifti1Header` into a version-agnostic [`NiftiHeader`] enum.
+    pub fn into_nifti(self) -> NiftiHeader {
+        NiftiHeader::Nifti1Header(self)
     }
 }
 
-    /// Check whether `pixdim[0]` is either -1 or 1.
-    #[inline]
-    fn is_pixdim_0_valid(&self) -> bool {
-        (self.pixdim[0].abs() - 1.).abs() < 1e-11
+impl Nifti2Header {
+    /// Place this `Nifti2Header` into a version-agnostic [`NiftiHeader`] enum.
+    pub fn into_nifti(self) -> NiftiHeader {
+        NiftiHeader::Nifti2Header(self)
     }
 }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -1001,9 +1001,9 @@ impl NiftiHeader {
     /// - If `pixdim[0]` isn't equal to -1.0 or 1.0, it will be set to 1.0
     pub fn fix(&mut self) {
         let mut pixdim = self.get_pixdim();
-        if !Self::is_pixdim_0_valid(pixdim[0]) {
+        if !self.is_pixdim_0_valid() {
             pixdim[0] = 1.;
-            self.set_pixdim(pixdim);
+            self.set_pixdim(&pixdim);
         }
     }
 
@@ -1113,8 +1113,8 @@ impl NiftiHeader {
 
     /// Check whether `pixdim[0]` is either -1 or 1.
     #[inline]
-    fn is_pixdim_0_valid(pixdim0: f64) -> bool {
-        (pixdim0.abs() - 1.).abs() < 1e-11
+    fn is_pixdim_0_valid(&self) -> bool {
+        (self.get_pixdim()[0].abs() - 1.).abs() < 1e-11
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ pub mod writer;
 pub use byteordered::Endianness;
 pub use error::{NiftiError, Result};
 pub use extension::{Extender, Extension, ExtensionSequence};
-pub use header::NiftiHeader;
+pub use header::{NiftiHeader, Nifti1Header, Nifti2Header};
 pub use object::{
     InMemNiftiObject, NiftiObject, ReaderOptions, ReaderStreamedOptions, StreamedNiftiObject,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ pub mod writer;
 pub use byteordered::Endianness;
 pub use error::{NiftiError, Result};
 pub use extension::{Extender, Extension, ExtensionSequence};
-pub use header::{NiftiHeader, Nifti1Header, Nifti2Header};
+pub use header::{Nifti1Header, Nifti2Header, NiftiHeader};
 pub use object::{
     InMemNiftiObject, NiftiObject, ReaderOptions, ReaderStreamedOptions, StreamedNiftiObject,
 };

--- a/src/object.rs
+++ b/src/object.rs
@@ -467,7 +467,7 @@ impl<V> GenericNiftiObject<V> {
         V: FromSource<R>,
     {
         let header = NiftiHeader::from_reader(&mut source)?;
-        if &header.get_magic() == MAGIC_CODE_NI1 || &header.get_magic() == MAGIC_CODE_NI2 {
+        if &header.magic() == MAGIC_CODE_NI1 || &header.magic() == MAGIC_CODE_NI2 {
             // Magic code tells us reader is the .hdr file in an .hdr/.img
             // combination.  Extensions and volume are in another file/reader.
             return Err(NiftiError::NoVolumeData);
@@ -502,15 +502,15 @@ impl<V> GenericNiftiObject<V> {
         V: FromSource<R>,
     {
         // fetch extensions
-        let len: usize = header.get_vox_offset()?.try_into()?;
+        let len: usize = header.vox_offset()?.try_into()?;
         let len = if len == 0 {
             0
         } else {
-            len - TryInto::<usize>::try_into(header.get_sizeof_hdr())?
+            len - TryInto::<usize>::try_into(header.sizeof_hdr())?
         }; // TODO!
 
         let ext = {
-            let source = ByteOrdered::runtime(&mut source, header.get_endianness());
+            let source = ByteOrdered::runtime(&mut source, header.endianness());
             ExtensionSequence::from_reader(extender, source, len)?
         };
 
@@ -530,8 +530,8 @@ impl<V> GenericNiftiObject<V> {
         V: FromSource<MaybeGzDecodedFile>,
     {
         let header = NiftiHeader::from_reader(&mut stream)?;
-        let (volume, ext) = if &header.get_magic() == MAGIC_CODE_NI1
-            || &header.get_magic() == MAGIC_CODE_NI2
+        let (volume, ext) = if &header.magic() == MAGIC_CODE_NI1
+            || &header.magic() == MAGIC_CODE_NI2
         {
             // Magic code tells us reader is the .hdr file in an .hdr/.img
             // combination.  Extensions and volume are in another file/reader.
@@ -566,15 +566,15 @@ impl<V> GenericNiftiObject<V> {
             // extensions and volume are in the same source
 
             let extender = Extender::from_reader(&mut stream)?;
-            let len: usize = header.get_vox_offset()?.try_into()?;
+            let len: usize = header.vox_offset()?.try_into()?;
             let len = if len == 0 {
                 0
             } else {
-                len - TryInto::<usize>::try_into(header.get_sizeof_hdr())?
+                len - TryInto::<usize>::try_into(header.sizeof_hdr())?
             }; // TODO!
 
             let ext = {
-                let stream = ByteOrdered::runtime(&mut stream, header.get_endianness());
+                let stream = ByteOrdered::runtime(&mut stream, header.endianness());
                 ExtensionSequence::from_reader(extender, stream, len)?
             };
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -503,7 +503,11 @@ impl<V> GenericNiftiObject<V> {
     {
         // fetch extensions
         let len: usize = header.get_vox_offset()?.try_into()?;
-        let len = if len == 0 { 0 } else { len - TryInto::<usize>::try_into(header.get_sizeof_hdr())? }; // TODO!
+        let len = if len == 0 {
+            0
+        } else {
+            len - TryInto::<usize>::try_into(header.get_sizeof_hdr())?
+        }; // TODO!
 
         let ext = {
             let source = ByteOrdered::runtime(&mut source, header.get_endianness());
@@ -526,7 +530,9 @@ impl<V> GenericNiftiObject<V> {
         V: FromSource<MaybeGzDecodedFile>,
     {
         let header = NiftiHeader::from_reader(&mut stream)?;
-        let (volume, ext) = if &header.get_magic() == MAGIC_CODE_NI1 || &header.get_magic() == MAGIC_CODE_NI2 {
+        let (volume, ext) = if &header.get_magic() == MAGIC_CODE_NI1
+            || &header.get_magic() == MAGIC_CODE_NI2
+        {
             // Magic code tells us reader is the .hdr file in an .hdr/.img
             // combination.  Extensions and volume are in another file/reader.
 
@@ -561,7 +567,11 @@ impl<V> GenericNiftiObject<V> {
 
             let extender = Extender::from_reader(&mut stream)?;
             let len: usize = header.get_vox_offset()?.try_into()?;
-            let len = if len == 0 { 0 } else { len - TryInto::<usize>::try_into(header.get_sizeof_hdr())? }; // TODO!    
+            let len = if len == 0 {
+                0
+            } else {
+                len - TryInto::<usize>::try_into(header.get_sizeof_hdr())?
+            }; // TODO!
 
             let ext = {
                 let stream = ByteOrdered::runtime(&mut stream, header.get_endianness());

--- a/src/object.rs
+++ b/src/object.rs
@@ -505,7 +505,7 @@ impl<V> GenericNiftiObject<V> {
         let len = if len < 352 { 0 } else { len - 352 };
 
         let ext = {
-            let source = ByteOrdered::runtime(&mut source, header.endianness);
+            let source = ByteOrdered::runtime(&mut source, header.get_endianness());
             ExtensionSequence::from_reader(extender, source, len)?
         };
 
@@ -563,7 +563,7 @@ impl<V> GenericNiftiObject<V> {
             let len = if len < 352 { 0 } else { len - 352 };
 
             let ext = {
-                let stream = ByteOrdered::runtime(&mut stream, header.endianness);
+                let stream = ByteOrdered::runtime(&mut stream, header.get_endianness());
                 ExtensionSequence::from_reader(extender, stream, len)?
             };
 

--- a/src/typedef.rs
+++ b/src/typedef.rs
@@ -88,8 +88,8 @@ impl NiftiType {
         self,
         source: S,
         endianness: Endianness,
-        slope: f32,
-        inter: f32,
+        slope: f64,
+        inter: f64,
     ) -> Result<T>
     where
         S: Read,

--- a/src/util.rs
+++ b/src/util.rs
@@ -101,7 +101,7 @@ pub fn validate_dimensionality(raw_dim: &[u16; 8]) -> Result<usize> {
 pub fn nb_bytes_for_data(header: &NiftiHeader) -> Result<usize> {
     let resolution = nb_values_for_dims(header.dim()?);
     resolution
-        .and_then(|r| r.checked_mul(header.bitpix as usize / 8))
+        .and_then(|r| r.checked_mul(usize::from(header.get_bitpix()) / 8))
         .ok_or(NiftiError::BadVolumeSize)
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -102,7 +102,7 @@ pub fn validate_dimensionality(raw_dim: &[u64; 8]) -> Result<usize> {
 pub fn nb_bytes_for_data(header: &NiftiHeader) -> Result<usize> {
     let resolution = nb_values_for_dims(&header.dim()?);
     resolution
-        .and_then(|r| r.checked_mul(usize::from(header.get_bitpix()) / 8))
+        .and_then(|r| r.checked_mul(usize::from(header.bitpix()) / 8))
         .ok_or(NiftiError::BadVolumeSize)
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -110,7 +110,9 @@ pub fn nb_values_for_dims(dim: &[u64]) -> Option<usize> {
     dim.iter()
         .cloned()
         .map(TryInto::<usize>::try_into)
-        .fold(Some(1), |acc, v| acc.and_then(|x| v.map_or(None, |v| x.checked_mul(v))))
+        .fold(Some(1), |acc, v| {
+            acc.and_then(|x| v.map_or(None, |v| x.checked_mul(v)))
+        })
 }
 
 pub fn nb_bytes_for_dim_datatype(dim: &[u64], datatype: NiftiType) -> Option<usize> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,6 +8,7 @@ use either::Either;
 use flate2::bufread::GzDecoder;
 use safe_transmute::{transmute_vec, TriviallyTransmutable};
 use std::borrow::Cow;
+use std::convert::TryInto;
 use std::fs::File;
 use std::io::{BufReader, Read, Result as IoResult, Seek};
 use std::mem;
@@ -76,7 +77,7 @@ where
 ///
 /// Errors if `dim[0]` is outside the accepted rank boundaries or
 /// one of the used dimensions is not positive.
-pub fn validate_dim(raw_dim: &[u16; 8]) -> Result<&[u16]> {
+pub fn validate_dim(raw_dim: &[u64; 8]) -> Result<&[u64]> {
     let ndim = validate_dimensionality(raw_dim)?;
     let o = &raw_dim[1..=ndim];
     if let Some(i) = o.iter().position(|&x| x == 0) {
@@ -91,28 +92,28 @@ pub fn validate_dim(raw_dim: &[u16; 8]) -> Result<&[u16]> {
 ///
 /// Errors if `raw_dim[0]` is outside the accepted rank boundaries: 0 or
 /// larger than 7.
-pub fn validate_dimensionality(raw_dim: &[u16; 8]) -> Result<usize> {
+pub fn validate_dimensionality(raw_dim: &[u64; 8]) -> Result<usize> {
     if raw_dim[0] == 0 || raw_dim[0] > 7 {
         return Err(NiftiError::InconsistentDim(0, raw_dim[0]));
     }
-    Ok(usize::from(raw_dim[0]))
+    Ok(raw_dim[0].try_into()?)
 }
 
 pub fn nb_bytes_for_data(header: &NiftiHeader) -> Result<usize> {
-    let resolution = nb_values_for_dims(header.dim()?);
+    let resolution = nb_values_for_dims(&header.dim()?);
     resolution
         .and_then(|r| r.checked_mul(usize::from(header.get_bitpix()) / 8))
         .ok_or(NiftiError::BadVolumeSize)
 }
 
-pub fn nb_values_for_dims(dim: &[u16]) -> Option<usize> {
+pub fn nb_values_for_dims(dim: &[u64]) -> Option<usize> {
     dim.iter()
         .cloned()
-        .map(usize::from)
-        .fold(Some(1), |acc, v| acc.and_then(|x| x.checked_mul(v)))
+        .map(TryInto::<usize>::try_into)
+        .fold(Some(1), |acc, v| acc.and_then(|x| v.map_or(None, |v| x.checked_mul(v))))
 }
 
-pub fn nb_bytes_for_dim_datatype(dim: &[u16], datatype: NiftiType) -> Option<usize> {
+pub fn nb_bytes_for_dim_datatype(dim: &[u64], datatype: NiftiType) -> Option<usize> {
     let resolution = nb_values_for_dims(dim);
     resolution.and_then(|r| r.checked_mul(datatype.size_of()))
 }

--- a/src/volume/element.rs
+++ b/src/volume/element.rs
@@ -19,11 +19,11 @@ use std::ops::{Add, Mul};
 /// intercept arguments to `f64`.
 pub trait LinearTransform<T: 'static + Copy> {
     /// Linearly transform a value with the given slope and intercept.
-    fn linear_transform(value: T, slope: f32, intercept: f32) -> T;
+    fn linear_transform(value: T, slope: f64, intercept: f64) -> T;
 
     /// Linearly transform a sequence of values with the given slope and intercept into
     /// a vector.
-    fn linear_transform_many(value: &[T], slope: f32, intercept: f32) -> Vec<T> {
+    fn linear_transform_many(value: &[T], slope: f64, intercept: f64) -> Vec<T> {
         value
             .iter()
             .map(|x| Self::linear_transform(*x, slope, intercept))
@@ -31,7 +31,7 @@ pub trait LinearTransform<T: 'static + Copy> {
     }
 
     /// Linearly transform a sequence of values inline, with the given slope and intercept.
-    fn linear_transform_many_inline(value: &mut [T], slope: f32, intercept: f32) {
+    fn linear_transform_many_inline(value: &mut [T], slope: f64, intercept: f64) {
         for v in value.iter_mut() {
             *v = Self::linear_transform(*v, slope, intercept);
         }
@@ -42,17 +42,17 @@ pub trait LinearTransform<T: 'static + Copy> {
 /// affine transformation, then converted back to the original type. Ideal for
 /// small, low precision types such as `u8` and `i16`.
 #[derive(Debug)]
-pub struct LinearTransformViaF32;
+pub struct LinearTransformViaF32; // TODO remove this for NIFTI-2?
 
 impl<T> LinearTransform<T> for LinearTransformViaF32
 where
     T: 'static + Copy + DataElement,
 {
-    fn linear_transform(value: T, slope: f32, intercept: f32) -> T {
+    fn linear_transform(value: T, slope: f64, intercept: f64) -> T {
         if slope == 0. {
             return value;
         }
-        T::from_f32(AsPrimitive::<f32>::as_(value) * slope + intercept)
+        T::from_f32(AsPrimitive::<f32>::as_(value) * slope as f32 + intercept as f32)
     }
 }
 
@@ -66,7 +66,7 @@ impl<T> LinearTransform<T> for LinearTransformViaF64
 where
     T: 'static + Copy + DataElement,
 {
-    fn linear_transform(value: T, slope: f32, intercept: f32) -> T {
+    fn linear_transform(value: T, slope: f64, intercept: f64) -> T {
         if slope == 0. {
             return value;
         }
@@ -86,12 +86,12 @@ impl<T> LinearTransform<T> for LinearTransformViaOriginal
 where
     T: 'static + Copy + DataElement + Mul<Output = T> + Add<Output = T>,
 {
-    fn linear_transform(value: T, slope: f32, intercept: f32) -> T {
+    fn linear_transform(value: T, slope: f64, intercept: f64) -> T {
         if slope == 0. {
             return value;
         }
-        let slope = T::from_f32(slope);
-        let intercept = T::from_f32(intercept);
+        let slope = T::from_f64(slope);
+        let intercept = T::from_f64(intercept);
         value * slope + intercept
     }
 }

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -66,8 +66,8 @@ macro_rules! fn_convert_and_cast {
 pub struct InMemNiftiVolume {
     dim: Dim,
     datatype: NiftiType,
-    scl_slope: f32,
-    scl_inter: f32,
+    scl_slope: f64,
+    scl_inter: f64,
     raw_data: Vec<u8>,
     endianness: Endianness,
 }
@@ -98,10 +98,10 @@ impl InMemNiftiVolume {
     /// `endianness`, as specified by the volume shape in `raw_dim` and data
     /// type in `datatype`.
     pub fn from_raw_fields(
-        raw_dim: [u16; 8],
+        raw_dim: [u64; 8],
         datatype: NiftiType,
-        scl_slope: f32,
-        scl_inter: f32,
+        scl_slope: f64,
+        scl_inter: f64,
         raw_data: Vec<u8>,
         endianness: Endianness,
     ) -> Result<Self> {
@@ -184,7 +184,7 @@ impl InMemNiftiVolume {
         &mut self.raw_data
     }
 
-    fn get_prim<T>(&self, coords: &[u16]) -> Result<T>
+    fn get_prim<T>(&self, coords: &[u64]) -> Result<T>
     where
         T: DataElement,
         T: Num,
@@ -264,7 +264,7 @@ impl<'a> IntoNdArray for &'a InMemNiftiVolume {
 }
 
 impl<'a> NiftiVolume for &'a InMemNiftiVolume {
-    fn dim(&self) -> &[u16] {
+    fn dim(&self) -> &[u64] {
         (**self).dim()
     }
 
@@ -278,7 +278,7 @@ impl<'a> NiftiVolume for &'a InMemNiftiVolume {
 }
 
 impl NiftiVolume for InMemNiftiVolume {
-    fn dim(&self) -> &[u16] {
+    fn dim(&self) -> &[u64] {
         self.dim.as_ref()
     }
 
@@ -292,85 +292,85 @@ impl NiftiVolume for InMemNiftiVolume {
 }
 
 impl RandomAccessNiftiVolume for InMemNiftiVolume {
-    fn get_f32(&self, coords: &[u16]) -> Result<f32> {
+    fn get_f32(&self, coords: &[u64]) -> Result<f32> {
         self.get_prim(coords)
     }
 
-    fn get_f64(&self, coords: &[u16]) -> Result<f64> {
+    fn get_f64(&self, coords: &[u64]) -> Result<f64> {
         self.get_prim(coords)
     }
 
-    fn get_u8(&self, coords: &[u16]) -> Result<u8> {
+    fn get_u8(&self, coords: &[u64]) -> Result<u8> {
         self.get_prim(coords)
     }
 
-    fn get_i8(&self, coords: &[u16]) -> Result<i8> {
+    fn get_i8(&self, coords: &[u64]) -> Result<i8> {
         self.get_prim(coords)
     }
 
-    fn get_u16(&self, coords: &[u16]) -> Result<u16> {
+    fn get_u16(&self, coords: &[u64]) -> Result<u16> {
         self.get_prim(coords)
     }
 
-    fn get_i16(&self, coords: &[u16]) -> Result<i16> {
+    fn get_i16(&self, coords: &[u64]) -> Result<i16> {
         self.get_prim(coords)
     }
 
-    fn get_u32(&self, coords: &[u16]) -> Result<u32> {
+    fn get_u32(&self, coords: &[u64]) -> Result<u32> {
         self.get_prim(coords)
     }
 
-    fn get_i32(&self, coords: &[u16]) -> Result<i32> {
+    fn get_i32(&self, coords: &[u64]) -> Result<i32> {
         self.get_prim(coords)
     }
 
-    fn get_u64(&self, coords: &[u16]) -> Result<u64> {
+    fn get_u64(&self, coords: &[u64]) -> Result<u64> {
         self.get_prim(coords)
     }
 
-    fn get_i64(&self, coords: &[u16]) -> Result<i64> {
+    fn get_i64(&self, coords: &[u64]) -> Result<i64> {
         self.get_prim(coords)
     }
 }
 
 impl<'a> RandomAccessNiftiVolume for &'a InMemNiftiVolume {
-    fn get_f32(&self, coords: &[u16]) -> Result<f32> {
+    fn get_f32(&self, coords: &[u64]) -> Result<f32> {
         (**self).get_f32(coords)
     }
 
-    fn get_f64(&self, coords: &[u16]) -> Result<f64> {
+    fn get_f64(&self, coords: &[u64]) -> Result<f64> {
         (**self).get_f64(coords)
     }
 
-    fn get_u8(&self, coords: &[u16]) -> Result<u8> {
+    fn get_u8(&self, coords: &[u64]) -> Result<u8> {
         (**self).get_u8(coords)
     }
 
-    fn get_i8(&self, coords: &[u16]) -> Result<i8> {
+    fn get_i8(&self, coords: &[u64]) -> Result<i8> {
         (**self).get_i8(coords)
     }
 
-    fn get_u16(&self, coords: &[u16]) -> Result<u16> {
+    fn get_u16(&self, coords: &[u64]) -> Result<u16> {
         (**self).get_u16(coords)
     }
 
-    fn get_i16(&self, coords: &[u16]) -> Result<i16> {
+    fn get_i16(&self, coords: &[u64]) -> Result<i16> {
         (**self).get_i16(coords)
     }
 
-    fn get_u32(&self, coords: &[u16]) -> Result<u32> {
+    fn get_u32(&self, coords: &[u64]) -> Result<u32> {
         (**self).get_u32(coords)
     }
 
-    fn get_i32(&self, coords: &[u16]) -> Result<i32> {
+    fn get_i32(&self, coords: &[u64]) -> Result<i32> {
         (**self).get_i32(coords)
     }
 
-    fn get_u64(&self, coords: &[u16]) -> Result<u64> {
+    fn get_u64(&self, coords: &[u64]) -> Result<u64> {
         (**self).get_u64(coords)
     }
 
-    fn get_i64(&self, coords: &[u16]) -> Result<i64> {
+    fn get_i64(&self, coords: &[u64]) -> Result<i64> {
         (**self).get_i64(coords)
     }
 }

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -440,7 +440,7 @@ mod tests {
             bitpix: 8,
             ..Default::default()
         }
-        .into_nifti();
+        .into();
         let raw_data = vec![0; (w * h * d) as usize];
         let mut volume = InMemNiftiVolume::from_raw_data(&header, raw_data).unwrap();
         assert_eq!(header.get_dim()[0], 4);

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -439,7 +439,8 @@ mod tests {
             datatype: 2,
             bitpix: 8,
             ..Default::default()
-        }.into_nifti();
+        }
+        .into_nifti();
         let raw_data = vec![0; (w * h * d) as usize];
         let mut volume = InMemNiftiVolume::from_raw_data(&header, raw_data).unwrap();
         assert_eq!(header.get_dim()[0], 4);

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -438,15 +438,15 @@ mod tests {
     #[test]
     fn test_false_4d() {
         let (w, h, d) = (5, 5, 5);
-        let mut header = NiftiHeader {
+        let mut header = crate::header::Nifti1Header {
             dim: [4, w, h, d, 1, 1, 1, 1],
             datatype: 2,
             bitpix: 8,
             ..Default::default()
-        };
+        }.into_nifti();
         let raw_data = vec![0; (w * h * d) as usize];
         let mut volume = InMemNiftiVolume::from_raw_data(&header, raw_data).unwrap();
-        assert_eq!(header.dim[0], 4);
+        assert_eq!(header.get_dim()[0], 4);
         assert_eq!(volume.dimensionality(), 4);
         if header.get_dim()[header.get_dim()[0] as usize] == 1 {
             let mut dim = header.get_dim();

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -83,12 +83,12 @@ impl InMemNiftiVolume {
 
         let datatype = header.data_type()?;
         Ok(InMemNiftiVolume {
-            dim: Dim::new(header.dim)?,
+            dim: Dim::new(header.get_dim())?,
             datatype,
-            scl_slope: header.scl_slope,
-            scl_inter: header.scl_inter,
+            scl_slope: header.get_scl_slope(),
+            scl_inter: header.get_scl_inter(),
             raw_data,
-            endianness: header.endianness,
+            endianness: header.get_endianness(),
         })
     }
 
@@ -143,12 +143,12 @@ impl InMemNiftiVolume {
 
         let datatype = header.data_type()?;
         Ok(InMemNiftiVolume {
-            dim: Dim::new(header.dim)?,
+            dim: Dim::new(header.get_dim())?,
             datatype,
-            scl_slope: header.scl_slope,
-            scl_inter: header.scl_inter,
+            scl_slope: header.get_scl_slope(),
+            scl_inter: header.get_scl_inter(),
             raw_data,
-            endianness: header.endianness,
+            endianness: header.get_endianness(),
         })
     }
 
@@ -448,8 +448,10 @@ mod tests {
         let mut volume = InMemNiftiVolume::from_raw_data(&header, raw_data).unwrap();
         assert_eq!(header.dim[0], 4);
         assert_eq!(volume.dimensionality(), 4);
-        if header.dim[header.dim[0] as usize] == 1 {
-            header.dim[0] -= 1;
+        if header.get_dim()[header.get_dim()[0] as usize] == 1 {
+            let mut dim = header.get_dim();
+            dim[0] -= 1;
+            header.set_dim(&dim).unwrap();
             volume = InMemNiftiVolume::from_raw_data(&header, volume.into_raw_data()).unwrap();
         }
         assert_eq!(volume.dimensionality(), 3);

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -80,12 +80,12 @@ impl InMemNiftiVolume {
 
         let datatype = header.data_type()?;
         Ok(InMemNiftiVolume {
-            dim: Dim::new(header.get_dim())?,
+            dim: Dim::new(header.raw_dim())?,
             datatype,
-            scl_slope: header.get_scl_slope(),
-            scl_inter: header.get_scl_inter(),
+            scl_slope: header.scl_slope(),
+            scl_inter: header.scl_inter(),
             raw_data,
-            endianness: header.get_endianness(),
+            endianness: header.endianness(),
         })
     }
 
@@ -139,12 +139,12 @@ impl InMemNiftiVolume {
 
         let datatype = header.data_type()?;
         Ok(InMemNiftiVolume {
-            dim: Dim::new(header.get_dim())?,
+            dim: Dim::new(header.raw_dim())?,
             datatype,
-            scl_slope: header.get_scl_slope(),
-            scl_inter: header.get_scl_inter(),
+            scl_slope: header.scl_slope(),
+            scl_inter: header.scl_inter(),
             raw_data,
-            endianness: header.get_endianness(),
+            endianness: header.endianness(),
         })
     }
 
@@ -443,10 +443,10 @@ mod tests {
         .into();
         let raw_data = vec![0; (w * h * d) as usize];
         let mut volume = InMemNiftiVolume::from_raw_data(&header, raw_data).unwrap();
-        assert_eq!(header.get_dim()[0], 4);
+        assert_eq!(header.raw_dim()[0], 4);
         assert_eq!(volume.dimensionality(), 4);
-        if header.get_dim()[header.get_dim()[0] as usize] == 1 {
-            let mut dim = header.get_dim();
+        if header.raw_dim()[header.raw_dim()[0] as usize] == 1 {
+            let mut dim = header.raw_dim();
             dim[0] -= 1;
             header.set_dim(&dim).unwrap();
             volume = InMemNiftiVolume::from_raw_data(&header, volume.into_raw_data()).unwrap();

--- a/src/volume/mod.rs
+++ b/src/volume/mod.rs
@@ -29,7 +29,7 @@ pub trait NiftiVolume {
     /// Get the dimensions of the volume. Unlike how NIFTI-1
     /// stores dimensions, the returned slice does not include
     /// `dim[0]` and is clipped to the effective number of dimensions.
-    fn dim(&self) -> &[u16];
+    fn dim(&self) -> &[u64];
 
     /// Get the volume's number of dimensions. In a fully compliant file,
     /// this is equivalent to the corresponding header's `dim[0]` field
@@ -58,7 +58,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     ///
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
     /// volume's boundaries.
-    fn get_f64(&self, coords: &[u16]) -> Result<f64>;
+    fn get_f64(&self, coords: &[u64]) -> Result<f64>;
 
     /// Fetch a single voxel's value in the given voxel index coordinates
     /// as a single precision floating point value.
@@ -72,7 +72,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
     /// volume's boundaries.
     #[inline]
-    fn get_f32(&self, coords: &[u16]) -> Result<f32> {
+    fn get_f32(&self, coords: &[u64]) -> Result<f32> {
         self.get_f64(coords).map(|v| v as f32)
     }
 
@@ -88,7 +88,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
     /// volume's boundaries.
     #[inline]
-    fn get_u8(&self, coords: &[u16]) -> Result<u8> {
+    fn get_u8(&self, coords: &[u64]) -> Result<u8> {
         self.get_f64(coords).map(|v| v as u8)
     }
 
@@ -104,7 +104,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
     /// volume's boundaries.
     #[inline]
-    fn get_i8(&self, coords: &[u16]) -> Result<i8> {
+    fn get_i8(&self, coords: &[u64]) -> Result<i8> {
         self.get_f64(coords).map(|v| v as i8)
     }
 
@@ -120,7 +120,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
     /// volume's boundaries.
     #[inline]
-    fn get_u16(&self, coords: &[u16]) -> Result<u16> {
+    fn get_u16(&self, coords: &[u64]) -> Result<u16> {
         self.get_f64(coords).map(|v| v as u16)
     }
 
@@ -136,7 +136,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
     /// volume's boundaries.
     #[inline]
-    fn get_i16(&self, coords: &[u16]) -> Result<i16> {
+    fn get_i16(&self, coords: &[u64]) -> Result<i16> {
         self.get_f64(coords).map(|v| v as i16)
     }
 
@@ -152,7 +152,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
     /// volume's boundaries.
     #[inline]
-    fn get_u32(&self, coords: &[u16]) -> Result<u32> {
+    fn get_u32(&self, coords: &[u64]) -> Result<u32> {
         self.get_f64(coords).map(|v| v as u32)
     }
 
@@ -168,7 +168,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
     /// volume's boundaries.
     #[inline]
-    fn get_i32(&self, coords: &[u16]) -> Result<i32> {
+    fn get_i32(&self, coords: &[u64]) -> Result<i32> {
         self.get_f64(coords).map(|v| v as i32)
     }
 
@@ -184,7 +184,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
     /// volume's boundaries.
     #[inline]
-    fn get_u64(&self, coords: &[u16]) -> Result<u64> {
+    fn get_u64(&self, coords: &[u64]) -> Result<u64> {
         self.get_f64(coords).map(|v| v as u64)
     }
 
@@ -200,7 +200,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
     /// volume's boundaries.
     #[inline]
-    fn get_i64(&self, coords: &[u16]) -> Result<i64> {
+    fn get_i64(&self, coords: &[u64]) -> Result<i64> {
         self.get_f64(coords).map(|v| v as i64)
     }
 }
@@ -212,7 +212,7 @@ pub trait Sliceable {
 
     /// Obtain a slice of the volume over a certain axis, yielding a
     /// volume of N-1 dimensions.
-    fn get_slice(&self, axis: u16, index: u16) -> Result<Self::Slice>;
+    fn get_slice(&self, axis: u16, index: u64) -> Result<Self::Slice>;
 }
 
 /// Interface for specifying the type for the set of options that are relevent
@@ -243,8 +243,8 @@ pub trait FromSource<R>: FromSourceOptions + Sized {
 pub struct SliceView<T> {
     volume: T,
     axis: u16,
-    index: u16,
-    dim: Vec<u16>,
+    index: u64,
+    dim: Vec<u64>,
 }
 
 impl<'a, T> Sliceable for &'a T
@@ -253,7 +253,7 @@ where
 {
     type Slice = SliceView<&'a T>;
 
-    fn get_slice(&self, axis: u16, index: u16) -> Result<Self::Slice> {
+    fn get_slice(&self, axis: u16, index: u64) -> Result<Self::Slice> {
         let mut coords: Vec<_> = self.dim().into();
         if let Some(d) = coords.get(axis as usize) {
             if *d <= index {
@@ -283,7 +283,7 @@ where
     V: NiftiVolume,
 {
     #[inline]
-    fn dim(&self) -> &[u16] {
+    fn dim(&self) -> &[u64] {
         &self.dim
     }
 
@@ -302,61 +302,61 @@ impl<V> RandomAccessNiftiVolume for SliceView<V>
 where
     V: RandomAccessNiftiVolume,
 {
-    fn get_f32(&self, coords: &[u16]) -> Result<f32> {
+    fn get_f32(&self, coords: &[u64]) -> Result<f32> {
         let mut coords = Vec::from(coords);
         coords.insert(self.axis as usize, self.index);
         self.volume.get_f32(&coords)
     }
 
-    fn get_f64(&self, coords: &[u16]) -> Result<f64> {
+    fn get_f64(&self, coords: &[u64]) -> Result<f64> {
         let mut coords = Vec::from(coords);
         coords.insert(self.axis as usize, self.index);
         self.volume.get_f64(&coords)
     }
 
-    fn get_u8(&self, coords: &[u16]) -> Result<u8> {
+    fn get_u8(&self, coords: &[u64]) -> Result<u8> {
         let mut coords = Vec::from(coords);
         coords.insert(self.axis as usize, self.index);
         self.volume.get_u8(&coords)
     }
 
-    fn get_i8(&self, coords: &[u16]) -> Result<i8> {
+    fn get_i8(&self, coords: &[u64]) -> Result<i8> {
         let mut coords = Vec::from(coords);
         coords.insert(self.axis as usize, self.index);
         self.volume.get_i8(&coords)
     }
 
-    fn get_u16(&self, coords: &[u16]) -> Result<u16> {
+    fn get_u16(&self, coords: &[u64]) -> Result<u16> {
         let mut coords = Vec::from(coords);
         coords.insert(self.axis as usize, self.index);
         self.volume.get_u16(&coords)
     }
 
-    fn get_i16(&self, coords: &[u16]) -> Result<i16> {
+    fn get_i16(&self, coords: &[u64]) -> Result<i16> {
         let mut coords = Vec::from(coords);
         coords.insert(self.axis as usize, self.index);
         self.volume.get_i16(&coords)
     }
 
-    fn get_u32(&self, coords: &[u16]) -> Result<u32> {
+    fn get_u32(&self, coords: &[u64]) -> Result<u32> {
         let mut coords = Vec::from(coords);
         coords.insert(self.axis as usize, self.index);
         self.volume.get_u32(&coords)
     }
 
-    fn get_i32(&self, coords: &[u16]) -> Result<i32> {
+    fn get_i32(&self, coords: &[u64]) -> Result<i32> {
         let mut coords = Vec::from(coords);
         coords.insert(self.axis as usize, self.index);
         self.volume.get_i32(&coords)
     }
 
-    fn get_u64(&self, coords: &[u16]) -> Result<u64> {
+    fn get_u64(&self, coords: &[u64]) -> Result<u64> {
         let mut coords = Vec::from(coords);
         coords.insert(self.axis as usize, self.index);
         self.volume.get_u64(&coords)
     }
 
-    fn get_i64(&self, coords: &[u16]) -> Result<i64> {
+    fn get_i64(&self, coords: &[u64]) -> Result<i64> {
         let mut coords = Vec::from(coords);
         coords.insert(self.axis as usize, self.index);
         self.volume.get_i64(&coords)

--- a/src/volume/streamed.rs
+++ b/src/volume/streamed.rs
@@ -327,7 +327,7 @@ mod tests {
             endianness: Endianness::native(),
             ..Nifti1Header::default()
         }
-        .into_nifti();
+        .into();
 
         let mut volume = StreamedNiftiVolume::from_reader(&volume_data[..], &header).unwrap();
 
@@ -369,7 +369,7 @@ mod tests {
             endianness: Endianness::native(),
             ..Nifti1Header::default()
         }
-        .into_nifti();
+        .into();
 
         let mut volume = StreamedNiftiVolume::from_reader(&volume_data[..], &header).unwrap();
 
@@ -414,7 +414,7 @@ mod tests {
             endianness: Endianness::native(),
             ..Nifti1Header::default()
         }
-        .into_nifti();
+        .into();
 
         let mut volume = StreamedNiftiVolume::from_reader(&volume_data[..], &header).unwrap();
 
@@ -457,7 +457,7 @@ mod tests {
             endianness: Endianness::native(),
             ..Nifti1Header::default()
         }
-        .into_nifti();
+        .into();
 
         let mut volume =
             StreamedNiftiVolume::from_reader_rank(&volume_data[..], &header, 2).unwrap();
@@ -502,7 +502,7 @@ mod tests {
             endianness: Endianness::Little,
             ..Nifti1Header::default()
         }
-        .into_nifti();
+        .into();
 
         let mut volume =
             StreamedNiftiVolume::from_reader_rank(&volume_data[..], &header, 1).unwrap();

--- a/src/volume/streamed.rs
+++ b/src/volume/streamed.rs
@@ -326,7 +326,8 @@ mod tests {
             scl_inter: 0.,
             endianness: Endianness::native(),
             ..Nifti1Header::default()
-        }.into_nifti();
+        }
+        .into_nifti();
 
         let mut volume = StreamedNiftiVolume::from_reader(&volume_data[..], &header).unwrap();
 
@@ -367,7 +368,8 @@ mod tests {
             scl_inter: 0.,
             endianness: Endianness::native(),
             ..Nifti1Header::default()
-        }.into_nifti();
+        }
+        .into_nifti();
 
         let mut volume = StreamedNiftiVolume::from_reader(&volume_data[..], &header).unwrap();
 
@@ -411,7 +413,8 @@ mod tests {
             scl_inter: 0.,
             endianness: Endianness::native(),
             ..Nifti1Header::default()
-        }.into_nifti();
+        }
+        .into_nifti();
 
         let mut volume = StreamedNiftiVolume::from_reader(&volume_data[..], &header).unwrap();
 
@@ -453,7 +456,8 @@ mod tests {
             scl_inter: 0.,
             endianness: Endianness::native(),
             ..Nifti1Header::default()
-        }.into_nifti();
+        }
+        .into_nifti();
 
         let mut volume =
             StreamedNiftiVolume::from_reader_rank(&volume_data[..], &header, 2).unwrap();
@@ -497,7 +501,8 @@ mod tests {
             scl_inter: 0.,
             endianness: Endianness::Little,
             ..Nifti1Header::default()
-        }.into_nifti();
+        }
+        .into_nifti();
 
         let mut volume =
             StreamedNiftiVolume::from_reader_rank(&volume_data[..], &header, 1).unwrap();

--- a/src/volume/streamed.rs
+++ b/src/volume/streamed.rs
@@ -313,20 +313,20 @@ mod tests {
     use super::super::{NiftiVolume, RandomAccessNiftiVolume};
     use super::StreamedNiftiVolume;
     use crate::typedef::NiftiType;
-    use crate::NiftiHeader;
+    use crate::Nifti1Header;
     use byteordered::Endianness;
 
     #[test]
     fn test_streamed_base() {
         let volume_data = &[1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23];
-        let header = NiftiHeader {
+        let header = Nifti1Header {
             dim: [3, 2, 3, 2, 0, 0, 0, 0],
             datatype: NiftiType::Uint8 as i16,
             scl_slope: 1.,
             scl_inter: 0.,
             endianness: Endianness::native(),
-            ..NiftiHeader::default()
-        };
+            ..Nifti1Header::default()
+        }.into_nifti();
 
         let mut volume = StreamedNiftiVolume::from_reader(&volume_data[..], &header).unwrap();
 
@@ -360,14 +360,14 @@ mod tests {
     #[test]
     fn test_streamed_indexed() {
         let volume_data = &[1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23];
-        let header = NiftiHeader {
+        let header = Nifti1Header {
             dim: [3, 2, 3, 2, 0, 0, 0, 0],
             datatype: NiftiType::Uint8 as i16,
             scl_slope: 1.,
             scl_inter: 0.,
             endianness: Endianness::native(),
-            ..NiftiHeader::default()
-        };
+            ..Nifti1Header::default()
+        }.into_nifti();
 
         let mut volume = StreamedNiftiVolume::from_reader(&volume_data[..], &header).unwrap();
 
@@ -404,14 +404,14 @@ mod tests {
     #[test]
     fn test_streamed_inline() {
         let volume_data = &[1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23];
-        let header = NiftiHeader {
+        let header = Nifti1Header {
             dim: [3, 2, 3, 2, 0, 0, 0, 0],
             datatype: NiftiType::Uint8 as i16,
             scl_slope: 1.,
             scl_inter: 0.,
             endianness: Endianness::native(),
-            ..NiftiHeader::default()
-        };
+            ..Nifti1Header::default()
+        }.into_nifti();
 
         let mut volume = StreamedNiftiVolume::from_reader(&volume_data[..], &header).unwrap();
 
@@ -446,14 +446,14 @@ mod tests {
     #[test]
     fn test_streamed_ranked() {
         let volume_data = &[1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23];
-        let header = NiftiHeader {
+        let header = Nifti1Header {
             dim: [4, 2, 3, 2, 1, 0, 0, 0],
             datatype: NiftiType::Uint8 as i16,
             scl_slope: 1.,
             scl_inter: 0.,
             endianness: Endianness::native(),
-            ..NiftiHeader::default()
-        };
+            ..Nifti1Header::default()
+        }.into_nifti();
 
         let mut volume =
             StreamedNiftiVolume::from_reader_rank(&volume_data[..], &header, 2).unwrap();
@@ -490,14 +490,14 @@ mod tests {
         let volume_data = &[
             1, 0, 3, 0, 5, 0, 7, 0, 9, 0, 11, 0, 13, 0, 15, 0, 17, 0, 19, 0, 21, 0, 23, 0,
         ];
-        let header = NiftiHeader {
+        let header = Nifti1Header {
             dim: [3, 2, 3, 2, 0, 0, 0, 0],
             datatype: NiftiType::Uint16 as i16,
             scl_slope: 1.,
             scl_inter: 0.,
             endianness: Endianness::Little,
-            ..NiftiHeader::default()
-        };
+            ..Nifti1Header::default()
+        }.into_nifti();
 
         let mut volume =
             StreamedNiftiVolume::from_reader_rank(&volume_data[..], &header, 1).unwrap();

--- a/src/volume/streamed.rs
+++ b/src/volume/streamed.rs
@@ -78,8 +78,8 @@ pub struct StreamedNiftiVolume<R> {
     dim: Dim,
     slice_dim: Dim,
     datatype: NiftiType,
-    scl_slope: f32,
-    scl_inter: f32,
+    scl_slope: f64,
+    scl_inter: f64,
     endianness: Endianness,
     slices_read: usize,
     slices_left: usize,
@@ -141,12 +141,12 @@ where
     }
 
     /// Retrieve the full volume shape.
-    pub fn dim(&self) -> &[u16] {
+    pub fn dim(&self) -> &[u64] {
         self.dim.as_ref()
     }
 
     /// Retrieve the shape of the slices.
-    pub fn slice_dim(&self) -> &[u16] {
+    pub fn slice_dim(&self) -> &[u64] {
         self.slice_dim.as_ref()
     }
 
@@ -245,7 +245,7 @@ where
 }
 
 impl<'a, R> NiftiVolume for &'a StreamedNiftiVolume<R> {
-    fn dim(&self) -> &[u16] {
+    fn dim(&self) -> &[u64] {
         (**self).dim()
     }
 
@@ -259,7 +259,7 @@ impl<'a, R> NiftiVolume for &'a StreamedNiftiVolume<R> {
 }
 
 impl<R> NiftiVolume for StreamedNiftiVolume<R> {
-    fn dim(&self) -> &[u16] {
+    fn dim(&self) -> &[u64] {
         self.dim.as_ref()
     }
 
@@ -297,7 +297,7 @@ fn calculate_slice_dims(dim: &Dim, slice_rank: u16) -> Dim {
     assert!(dim.rank() > 0);
     assert!(usize::from(slice_rank) < dim.rank());
     let mut raw_dim = *dim.raw();
-    raw_dim[0] = slice_rank;
+    raw_dim[0] = slice_rank as u64;
     Dim::new(raw_dim).unwrap()
 }
 

--- a/src/volume/streamed.rs
+++ b/src/volume/streamed.rs
@@ -110,7 +110,7 @@ where
     ///
     /// By default, the slice's rank is the original volume's rank minus 1.
     pub fn from_reader(source: R, header: &NiftiHeader) -> Result<Self> {
-        let dim = Dim::new(header.get_dim())?;
+        let dim = Dim::new(header.raw_dim())?;
         let slice_rank = dim.rank() - 1;
         StreamedNiftiVolume::from_reader_rank(source, header, slice_rank as u16)
     }
@@ -123,7 +123,7 @@ where
     /// The slice rank defines how many dimensions each slice should have.
     pub fn from_reader_rank(source: R, header: &NiftiHeader, slice_rank: u16) -> Result<Self> {
         // TODO recoverable error if #dim == 0
-        let dim = Dim::new(header.get_dim())?; // check dim consistency
+        let dim = Dim::new(header.raw_dim())?; // check dim consistency
         let datatype = header.data_type()?;
         let slice_dim = calculate_slice_dims(&dim, slice_rank);
         let slices_left = calculate_total_slices(&dim, slice_rank);
@@ -132,9 +132,9 @@ where
             dim,
             slice_dim,
             datatype,
-            scl_slope: header.get_scl_slope(),
-            scl_inter: header.get_scl_inter(),
-            endianness: header.get_endianness(),
+            scl_slope: header.scl_slope(),
+            scl_inter: header.scl_inter(),
+            endianness: header.endianness(),
             slices_read: 0,
             slices_left,
         })

--- a/src/volume/streamed.rs
+++ b/src/volume/streamed.rs
@@ -110,7 +110,7 @@ where
     ///
     /// By default, the slice's rank is the original volume's rank minus 1.
     pub fn from_reader(source: R, header: &NiftiHeader) -> Result<Self> {
-        let dim = Dim::new(header.dim)?;
+        let dim = Dim::new(header.get_dim())?;
         let slice_rank = dim.rank() - 1;
         StreamedNiftiVolume::from_reader_rank(source, header, slice_rank as u16)
     }
@@ -123,7 +123,7 @@ where
     /// The slice rank defines how many dimensions each slice should have.
     pub fn from_reader_rank(source: R, header: &NiftiHeader, slice_rank: u16) -> Result<Self> {
         // TODO recoverable error if #dim == 0
-        let dim = Dim::new(header.dim)?; // check dim consistency
+        let dim = Dim::new(header.get_dim())?; // check dim consistency
         let datatype = header.data_type()?;
         let slice_dim = calculate_slice_dims(&dim, slice_rank);
         let slices_left = calculate_total_slices(&dim, slice_rank);
@@ -132,9 +132,9 @@ where
             dim,
             slice_dim,
             datatype,
-            scl_slope: header.scl_slope,
-            scl_inter: header.scl_inter,
-            endianness: header.endianness,
+            scl_slope: header.get_scl_slope(),
+            scl_inter: header.get_scl_inter(),
+            endianness: header.get_endianness(),
             slices_read: 0,
             slices_left,
         })

--- a/src/volume/util.rs
+++ b/src/volume/util.rs
@@ -12,7 +12,7 @@ where
     v
 }
 
-pub fn coords_to_index(coords: &[u16], dim: &[u16]) -> Result<usize> {
+pub fn coords_to_index(coords: &[u64], dim: &[u64]) -> Result<usize> {
     if coords.len() != dim.len() || coords.is_empty() {
         return Err(NiftiError::IncorrectVolumeDimensionality(
             dim.len() as u16,
@@ -20,7 +20,7 @@ pub fn coords_to_index(coords: &[u16], dim: &[u16]) -> Result<usize> {
         ));
     }
 
-    if !coords.iter().zip(dim).all(|(i, d)| *i < (*d) as u16) {
+    if !coords.iter().zip(dim).all(|(i, d)| *i < *d) {
         return Err(NiftiError::OutOfBounds(Vec::from(coords)));
     }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -11,10 +11,10 @@ use ndarray::{ArrayBase, Axis, Data, Dimension, RemoveAxis};
 use safe_transmute::{transmute_to_bytes, TriviallyTransmutable};
 
 use crate::{
-    header::{MAGIC_CODE_NI1, MAGIC_CODE_NIP1},
+    header::{MAGIC_CODE_NI1, MAGIC_CODE_NIP1, MAGIC_CODE_NI2, MAGIC_CODE_NIP2},
     util::{adapt_bytes, is_gz_file, is_hdr_file},
     volume::shape::Dim,
-    DataElement, NiftiHeader, NiftiType, Result,
+    DataElement, NiftiHeader, Nifti1Header, Nifti2Header, NiftiType, Result,
 };
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -145,18 +145,18 @@ impl<'a> WriterOptions<'a> {
         let data = data.t();
 
         let header_file = File::create(header_path)?;
-        if header.get_vox_offset()? > 0 {
+        if header.vox_offset()? > 0 {
             if let Some(compression_level) = self.compression {
                 let mut writer = ByteOrdered::runtime(
                     GzEncoder::new(header_file, compression_level),
-                    header.get_endianness(),
+                    header.endianness(),
                 );
                 write_header(writer.as_mut(), &header)?;
                 write_data::<_, A, _, _, _, _>(writer.as_mut(), data)?;
                 let _ = writer.into_inner().finish()?;
             } else {
                 let mut writer =
-                    ByteOrdered::runtime(BufWriter::new(header_file), header.get_endianness());
+                    ByteOrdered::runtime(BufWriter::new(header_file), header.endianness());
                 write_header(writer.as_mut(), &header)?;
                 write_data::<_, A, _, _, _, _>(writer, data)?;
             }
@@ -165,23 +165,23 @@ impl<'a> WriterOptions<'a> {
             if let Some(compression_level) = self.compression {
                 let mut writer = ByteOrdered::runtime(
                     GzEncoder::new(header_file, compression_level),
-                    header.get_endianness(),
+                    header.endianness(),
                 );
                 write_header(writer.as_mut(), &header)?;
                 let _ = writer.into_inner().finish()?;
 
                 let mut writer = ByteOrdered::runtime(
                     GzEncoder::new(data_file, compression_level),
-                    header.get_endianness(),
+                    header.endianness(),
                 );
                 write_data::<_, A, _, _, _, _>(writer.as_mut(), data)?;
                 let _ = writer.into_inner().finish()?;
             } else {
                 let header_writer =
-                    ByteOrdered::runtime(BufWriter::new(header_file), header.get_endianness());
+                    ByteOrdered::runtime(BufWriter::new(header_file), header.endianness());
                 write_header(header_writer, &header)?;
                 let data_writer =
-                    ByteOrdered::runtime(BufWriter::new(data_file), header.get_endianness());
+                    ByteOrdered::runtime(BufWriter::new(data_file), header.endianness());
                 write_data::<_, A, _, _, _, _>(data_writer, data)?;
             }
         }
@@ -202,18 +202,18 @@ impl<'a> WriterOptions<'a> {
         let data = data.t();
 
         let header_file = File::create(header_path)?;
-        if header.get_vox_offset()? > 0 {
+        if header.vox_offset()? > 0 {
             if let Some(compression_level) = self.compression {
                 let mut writer = ByteOrdered::runtime(
                     GzEncoder::new(header_file, compression_level),
-                    header.get_endianness(),
+                    header.endianness(),
                 );
                 write_header(writer.as_mut(), &header)?;
                 write_data::<_, u8, _, _, _, _>(writer.as_mut(), data)?;
                 let _ = writer.into_inner().finish()?;
             } else {
                 let mut writer =
-                    ByteOrdered::runtime(BufWriter::new(header_file), header.get_endianness());
+                    ByteOrdered::runtime(BufWriter::new(header_file), header.endianness());
                 write_header(writer.as_mut(), &header)?;
                 write_data::<_, u8, _, _, _, _>(writer, data)?;
             }
@@ -222,24 +222,24 @@ impl<'a> WriterOptions<'a> {
             if let Some(compression_level) = self.compression {
                 let mut writer = ByteOrdered::runtime(
                     GzEncoder::new(header_file, compression_level),
-                    header.get_endianness(),
+                    header.endianness(),
                 );
                 write_header(writer.as_mut(), &header)?;
                 let _ = writer.into_inner().finish()?;
 
                 let mut writer = ByteOrdered::runtime(
                     GzEncoder::new(data_file, compression_level),
-                    header.get_endianness(),
+                    header.endianness(),
                 );
                 write_data::<_, u8, _, _, _, _>(writer.as_mut(), data)?;
                 let _ = writer.into_inner().finish()?;
             } else {
                 let header_writer =
-                    ByteOrdered::runtime(BufWriter::new(header_file), header.get_endianness());
+                    ByteOrdered::runtime(BufWriter::new(header_file), header.endianness());
                 write_header(header_writer, &header)?;
 
                 let data_writer =
-                    ByteOrdered::runtime(BufWriter::new(data_file), header.get_endianness());
+                    ByteOrdered::runtime(BufWriter::new(data_file), header.endianness());
                 write_data::<_, u8, _, _, _, _>(data_writer, data)?;
             }
         }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -304,7 +304,7 @@ where
     W: Write,
     E: Endian,
 {
-    writer.write_i32(header.sizeof_hdr)?;
+    writer.write_i32(header.sizeof_hdr as i32)?;
     writer.write_all(&header.data_type)?;
     writer.write_all(&header.db_name)?;
     writer.write_i32(header.extents)?;
@@ -319,17 +319,17 @@ where
     writer.write_f32(header.intent_p3)?;
     writer.write_i16(header.intent_code)?;
     writer.write_i16(header.datatype)?;
-    writer.write_i16(header.bitpix)?;
-    writer.write_i16(header.slice_start)?;
+    writer.write_i16(header.bitpix.try_into()?)?;
+    writer.write_i16(header.slice_start.try_into()?)?;
     for f in &header.pixdim {
         writer.write_f32(*f)?;
     }
     writer.write_f32(header.vox_offset)?;
     writer.write_f32(header.scl_slope)?;
     writer.write_f32(header.scl_inter)?;
-    writer.write_i16(header.slice_end)?;
-    writer.write_u8(header.slice_code)?;
-    writer.write_u8(header.xyzt_units)?;
+    writer.write_i16(header.slice_end.try_into()?)?;
+    writer.write_i8(header.slice_code)?;
+    writer.write_i8(header.xyzt_units)?;
     writer.write_f32(header.cal_max)?;
     writer.write_f32(header.cal_min)?;
     writer.write_f32(header.slice_duration)?;

--- a/tests/affine.rs
+++ b/tests/affine.rs
@@ -14,8 +14,8 @@ mod nalgebra_affine {
         let affine = Affine4::from_diagonal(&Vector4::new(2.0, 2.0, 2.0, 1.0));
         header.set_affine(&affine);
         assert_eq!(affine, header.affine());
-        assert_eq!(header.get_sform_code(), 2);
-        assert_eq!(header.get_qform_code(), 0);
+        assert_eq!(header.sform_code(), 2);
+        assert_eq!(header.qform_code(), 0);
     }
 
     #[test]

--- a/tests/affine.rs
+++ b/tests/affine.rs
@@ -14,19 +14,19 @@ mod nalgebra_affine {
         let affine = Affine4::from_diagonal(&Vector4::new(2.0, 2.0, 2.0, 1.0));
         header.set_affine(&affine);
         assert_eq!(affine, header.affine());
-        assert_eq!(header.sform_code, 2);
-        assert_eq!(header.qform_code, 0);
+        assert_eq!(header.get_sform_code(), 2);
+        assert_eq!(header.get_qform_code(), 0);
     }
 
     #[test]
     #[rustfmt::skip]
     fn sform() {
         let mut header = NiftiHeader::default();
-        header.sform_code = 1;
-        header.qform_code = 0;
-        header.srow_x = [2.4, -0.0008, -0.0411765, -114.766396];
-        header.srow_y = [0.1, 2.4995277, 0.0485984, -97.420204];
-        header.srow_z = [0.4, -0.0485, 2.4991884, -89.12282];
+        header.set_sform_code(1).unwrap();
+        header.set_qform_code(0).unwrap();
+        header.set_srow_x(&[2.4, -0.0008, -0.0411765, -114.766396]);
+        header.set_srow_y(&[0.1, 2.4995277, 0.0485984, -97.420204]);
+        header.set_srow_z(&[0.4, -0.0485, 2.4991884, -89.12282]);
 
         let real_affine = Affine4::new(
             2.4, -0.0008,    -0.0411765, -114.766396,
@@ -41,15 +41,15 @@ mod nalgebra_affine {
     #[rustfmt::skip]
     fn qform() {
         let mut header = NiftiHeader::default();
-        header.sform_code = 0;
-        header.qform_code = 1;
-        header.pixdim = [-1.0, 0.9375, 0.9375, 3.0, 0.0, 0.0, 0.0, 0.0];
-        header.quatern_b = 0.0;
-        header.quatern_c = 1.0;
-        header.quatern_d = 0.0;
-        header.quatern_x = 59.557503;
-        header.quatern_y = 73.172;
-        header.quatern_z = 43.4291;
+        header.set_sform_code(0).unwrap();
+        header.set_qform_code(1).unwrap();
+        header.set_pixdim(&[-1.0, 0.9375, 0.9375, 3.0, 0.0, 0.0, 0.0, 0.0]);
+        header.set_quatern_b(0.0);
+        header.set_quatern_c(1.0);
+        header.set_quatern_d(0.0);
+        header.set_quatern_x(59.557503);
+        header.set_quatern_y(73.172);
+        header.set_quatern_z(43.4291);
 
         let real_affine = Affine4::new(
             -0.9375, 0.0,    0.0, 59.557503,
@@ -64,20 +64,20 @@ mod nalgebra_affine {
     #[rustfmt::skip]
     fn both_valid() {
         let mut header = NiftiHeader::default();
-        header.sform_code = 1;
-        header.srow_x = [2.4, 0.0, 0.0, -114.766396];
-        header.srow_y = [0.1, 2.4, 0.0, -97.420204];
-        header.srow_z = [0.4, 0.4, 2.4, -89.12282];
+        header.set_sform_code(1).unwrap();
+        header.set_srow_x(&[2.4, 0.0, 0.0, -114.766396]);
+        header.set_srow_y(&[0.1, 2.4, 0.0, -97.420204]);
+        header.set_srow_z(&[0.4, 0.4, 2.4, -89.12282]);
 
         // All this should be ignored
-        header.qform_code = 1;
-        header.pixdim = [-1.0, 0.9375, 0.9375, 3.0, 0.0, 0.0, 0.0, 0.0];
-        header.quatern_b = 0.0;
-        header.quatern_c = 1.0;
-        header.quatern_d = 0.0;
-        header.quatern_x = 59.0;
-        header.quatern_y = 73.0;
-        header.quatern_z = 43.0;
+        header.set_qform_code(1).unwrap();
+        header.set_pixdim(&[-1.0, 0.9375, 0.9375, 3.0, 0.0, 0.0, 0.0, 0.0]);
+        header.set_quatern_b(0.0);
+        header.set_quatern_c(1.0);
+        header.set_quatern_d(0.0);
+        header.set_quatern_x(59.0);
+        header.set_quatern_y(73.0);
+        header.set_quatern_z(43.0);
 
         let real_affine = Affine4::new(
             2.4, 0.0, 0.0, -114.766396,
@@ -92,21 +92,21 @@ mod nalgebra_affine {
     #[rustfmt::skip]
     fn none_valid() {
         let mut header = NiftiHeader::default();
-        header.dim = [3, 100, 100, 100, 0, 0, 0, 0];
-        header.pixdim = [-1.0, 0.9, 0.9, 3.0, 0.0, 0.0, 0.0, 0.0];
+        header.set_dim(&[3, 100, 100, 100, 0, 0, 0, 0]).unwrap();
+        header.set_pixdim(&[-1.0, 0.9, 0.9, 3.0, 0.0, 0.0, 0.0, 0.0]);
 
         // All this should be ignored, because only `shape_zoom_affine` will be called.
-        header.sform_code = 0;
-        header.srow_x = [1.0, 0.0, 0.0, 1.0];
-        header.srow_y = [0.0, 1.0, 0.0, 1.0];
-        header.srow_z = [0.0, 0.0, 1.0, 1.0];
-        header.qform_code = 0;
-        header.quatern_b = 0.0;
-        header.quatern_c = 1.0;
-        header.quatern_d = 0.0;
-        header.quatern_x = 59.0;
-        header.quatern_y = 73.0;
-        header.quatern_z = 43.0;
+        header.set_sform_code(0).unwrap();
+        header.set_srow_x(&[1.0, 0.0, 0.0, 1.0]);
+        header.set_srow_y(&[0.0, 1.0, 0.0, 1.0]);
+        header.set_srow_z(&[0.0, 0.0, 1.0, 1.0]);
+        header.set_qform_code(0).unwrap();
+        header.set_quatern_b(0.0);
+        header.set_quatern_c(1.0);
+        header.set_quatern_d(0.0);
+        header.set_quatern_x(59.0);
+        header.set_quatern_y(73.0);
+        header.set_quatern_z(43.0);
 
         let real_affine = Affine4::new(
             -0.9, 0.0, 0.0,   44.55,

--- a/tests/header.rs
+++ b/tests/header.rs
@@ -91,7 +91,7 @@ fn avg152T1_LR_hdr_gz() {
         endianness: Endianness::Big,
         ..Default::default()
     }
-    .into_nifti();
+    .into();
 
     const FILE_NAME: &str = "resources/avg152T1_LR_nifti.hdr.gz";
     let header = NiftiHeader::from_file(FILE_NAME).unwrap();
@@ -136,7 +136,7 @@ fn avg152T1_LR_nii_gz() {
         endianness: Endianness::Big,
         ..Default::default()
     }
-    .into_nifti();
+    .into();
 
     const FILE_NAME: &str = "resources/avg152T1_LR_nifti.nii.gz";
     let header = NiftiHeader::from_file(FILE_NAME).unwrap();
@@ -181,7 +181,7 @@ fn zstat1_nii_gz() {
         endianness: Endianness::Big,
         ..Default::default()
     }
-    .into_nifti();
+    .into();
 
     const FILE_NAME: &str = "resources/zstat1.nii.gz";
     let header = NiftiHeader::from_file(FILE_NAME).unwrap();

--- a/tests/header.rs
+++ b/tests/header.rs
@@ -52,7 +52,7 @@ fn minimal_nii() {
     let header = NiftiHeader::from_reader(file).unwrap();
 
     assert_eq!(header, minimal_hdr);
-    assert_eq!(header.get_endianness(), Endianness::Big);
+    assert_eq!(header.endianness(), Endianness::Big);
 
     assert_eq!(header.intent().unwrap(), Intent::None);
     assert_eq!(header.data_type().unwrap(), NiftiType::Uint8);
@@ -97,7 +97,7 @@ fn avg152T1_LR_hdr_gz() {
     let header = NiftiHeader::from_file(FILE_NAME).unwrap();
 
     assert_eq!(header, avg152t1_lr_hdr);
-    assert_eq!(header.get_endianness(), Endianness::Big);
+    assert_eq!(header.endianness(), Endianness::Big);
 
     assert_eq!(header.intent().unwrap(), Intent::None);
     assert_eq!(header.data_type().unwrap(), NiftiType::Uint8);

--- a/tests/header.rs
+++ b/tests/header.rs
@@ -2,7 +2,7 @@ extern crate nifti;
 #[macro_use]
 extern crate pretty_assertions;
 
-use nifti::{Endianness, Intent, NiftiHeader, Nifti1Header, NiftiType, SliceOrder, Unit, XForm};
+use nifti::{Endianness, Intent, Nifti1Header, NiftiHeader, NiftiType, SliceOrder, Unit, XForm};
 use std::fs::File;
 
 mod util;
@@ -90,7 +90,8 @@ fn avg152T1_LR_hdr_gz() {
         magic: *b"ni1\0",
         endianness: Endianness::Big,
         ..Default::default()
-    }.into_nifti();
+    }
+    .into_nifti();
 
     const FILE_NAME: &str = "resources/avg152T1_LR_nifti.hdr.gz";
     let header = NiftiHeader::from_file(FILE_NAME).unwrap();
@@ -134,7 +135,8 @@ fn avg152T1_LR_nii_gz() {
         magic: *b"n+1\0",
         endianness: Endianness::Big,
         ..Default::default()
-    }.into_nifti();
+    }
+    .into_nifti();
 
     const FILE_NAME: &str = "resources/avg152T1_LR_nifti.nii.gz";
     let header = NiftiHeader::from_file(FILE_NAME).unwrap();
@@ -178,7 +180,8 @@ fn zstat1_nii_gz() {
         magic: *b"n+1\0",
         endianness: Endianness::Big,
         ..Default::default()
-    }.into_nifti();
+    }
+    .into_nifti();
 
     const FILE_NAME: &str = "resources/zstat1.nii.gz";
     let header = NiftiHeader::from_file(FILE_NAME).unwrap();

--- a/tests/header.rs
+++ b/tests/header.rs
@@ -2,7 +2,7 @@ extern crate nifti;
 #[macro_use]
 extern crate pretty_assertions;
 
-use nifti::{Endianness, Intent, NiftiHeader, NiftiType, SliceOrder, Unit, XForm};
+use nifti::{Endianness, Intent, NiftiHeader, Nifti1Header, NiftiType, SliceOrder, Unit, XForm};
 use std::fs::File;
 
 mod util;
@@ -52,7 +52,7 @@ fn minimal_nii() {
     let header = NiftiHeader::from_reader(file).unwrap();
 
     assert_eq!(header, minimal_hdr);
-    assert_eq!(header.endianness, Endianness::Big);
+    assert_eq!(header.get_endianness(), Endianness::Big);
 
     assert_eq!(header.intent().unwrap(), Intent::None);
     assert_eq!(header.data_type().unwrap(), NiftiType::Uint8);
@@ -65,10 +65,9 @@ fn minimal_nii() {
 #[test]
 #[allow(non_snake_case)]
 fn avg152T1_LR_hdr_gz() {
-    let mut descrip = Vec::with_capacity(80);
-    descrip.extend(b"FSL3.2beta");
-    descrip.resize(80, 0);
-    let avg152t1_lr_hdr = NiftiHeader {
+    let mut descrip = [0; 80];
+    descrip[..10].copy_from_slice(b"FSL3.2beta");
+    let avg152t1_lr_hdr = Nifti1Header {
         sizeof_hdr: 348,
         regular: b'r',
         dim: [3, 91, 109, 91, 1, 1, 1, 1],
@@ -91,13 +90,13 @@ fn avg152T1_LR_hdr_gz() {
         magic: *b"ni1\0",
         endianness: Endianness::Big,
         ..Default::default()
-    };
+    }.into_nifti();
 
     const FILE_NAME: &str = "resources/avg152T1_LR_nifti.hdr.gz";
     let header = NiftiHeader::from_file(FILE_NAME).unwrap();
 
     assert_eq!(header, avg152t1_lr_hdr);
-    assert_eq!(header.endianness, Endianness::Big);
+    assert_eq!(header.get_endianness(), Endianness::Big);
 
     assert_eq!(header.intent().unwrap(), Intent::None);
     assert_eq!(header.data_type().unwrap(), NiftiType::Uint8);
@@ -110,10 +109,9 @@ fn avg152T1_LR_hdr_gz() {
 #[test]
 #[allow(non_snake_case)]
 fn avg152T1_LR_nii_gz() {
-    let mut descrip = Vec::with_capacity(80);
-    descrip.extend(b"FSL3.2beta");
-    descrip.resize(80, 0);
-    let avg152t1_lr_hdr = NiftiHeader {
+    let mut descrip = [0; 80];
+    descrip[..10].copy_from_slice(b"FSL3.2beta");
+    let avg152t1_lr_hdr = Nifti1Header {
         sizeof_hdr: 348,
         regular: b'r',
         dim: [3, 91, 109, 91, 1, 1, 1, 1],
@@ -136,7 +134,7 @@ fn avg152T1_LR_nii_gz() {
         magic: *b"n+1\0",
         endianness: Endianness::Big,
         ..Default::default()
-    };
+    }.into_nifti();
 
     const FILE_NAME: &str = "resources/avg152T1_LR_nifti.nii.gz";
     let header = NiftiHeader::from_file(FILE_NAME).unwrap();
@@ -153,10 +151,9 @@ fn avg152T1_LR_nii_gz() {
 
 #[test]
 fn zstat1_nii_gz() {
-    let mut descrip = Vec::with_capacity(80);
-    descrip.extend(b"FSL3.2beta");
-    descrip.resize(80, 0);
-    let zstat1_hdr = NiftiHeader {
+    let mut descrip = [0; 80];
+    descrip[..10].copy_from_slice(b"FSL3.2beta");
+    let zstat1_hdr = Nifti1Header {
         sizeof_hdr: 348,
         regular: b'r',
         dim: [3, 64, 64, 21, 1, 1, 1, 1],
@@ -181,7 +178,7 @@ fn zstat1_nii_gz() {
         magic: *b"n+1\0",
         endianness: Endianness::Big,
         ..Default::default()
-    };
+    }.into_nifti();
 
     const FILE_NAME: &str = "resources/zstat1.nii.gz";
     let header = NiftiHeader::from_file(FILE_NAME).unwrap();

--- a/tests/object.rs
+++ b/tests/object.rs
@@ -6,7 +6,7 @@ extern crate nifti;
 extern crate pretty_assertions;
 
 use nifti::{
-    Endianness, NiftiHeader, NiftiObject, NiftiType, NiftiVolume, RandomAccessNiftiVolume,
+    Endianness, Nifti1Header, NiftiObject, NiftiType, NiftiVolume, RandomAccessNiftiVolume,
     ReaderOptions, ReaderStreamedOptions, XForm,
 };
 
@@ -128,7 +128,7 @@ fn minimal_by_pair() {
 
 #[test]
 fn f32_nii_gz() {
-    let f32_hdr = NiftiHeader {
+    let f32_hdr = Nifti1Header {
         sizeof_hdr: 348,
         dim: [3, 11, 11, 11, 1, 1, 1, 1],
         datatype: 16,
@@ -144,7 +144,7 @@ fn f32_nii_gz() {
         magic: *b"n+1\0",
         endianness: Endianness::Little,
         ..Default::default()
-    };
+    }.into_nifti();
 
     const FILE_NAME: &str = "resources/f32.nii.gz";
     let obj = ReaderOptions::new().read_file(FILE_NAME).unwrap();
@@ -166,7 +166,7 @@ fn f32_nii_gz() {
 
 #[test]
 fn streamed_f32_nii_gz() {
-    let f32_hdr = NiftiHeader {
+    let f32_hdr = Nifti1Header {
         sizeof_hdr: 348,
         dim: [3, 11, 11, 11, 1, 1, 1, 1],
         datatype: 16,
@@ -182,7 +182,7 @@ fn streamed_f32_nii_gz() {
         magic: *b"n+1\0",
         endianness: Endianness::Little,
         ..Default::default()
-    };
+    }.into_nifti();
 
     const FILE_NAME: &str = "resources/f32.nii.gz";
     let obj = ReaderStreamedOptions::new().read_file(FILE_NAME).unwrap();

--- a/tests/object.rs
+++ b/tests/object.rs
@@ -145,7 +145,7 @@ fn f32_nii_gz() {
         endianness: Endianness::Little,
         ..Default::default()
     }
-    .into_nifti();
+    .into();
 
     const FILE_NAME: &str = "resources/f32.nii.gz";
     let obj = ReaderOptions::new().read_file(FILE_NAME).unwrap();
@@ -184,7 +184,7 @@ fn streamed_f32_nii_gz() {
         endianness: Endianness::Little,
         ..Default::default()
     }
-    .into_nifti();
+    .into();
 
     const FILE_NAME: &str = "resources/f32.nii.gz";
     let obj = ReaderStreamedOptions::new().read_file(FILE_NAME).unwrap();

--- a/tests/object.rs
+++ b/tests/object.rs
@@ -144,7 +144,8 @@ fn f32_nii_gz() {
         magic: *b"n+1\0",
         endianness: Endianness::Little,
         ..Default::default()
-    }.into_nifti();
+    }
+    .into_nifti();
 
     const FILE_NAME: &str = "resources/f32.nii.gz";
     let obj = ReaderOptions::new().read_file(FILE_NAME).unwrap();
@@ -182,7 +183,8 @@ fn streamed_f32_nii_gz() {
         magic: *b"n+1\0",
         endianness: Endianness::Little,
         ..Default::default()
-    }.into_nifti();
+    }
+    .into_nifti();
 
     const FILE_NAME: &str = "resources/f32.nii.gz";
     let obj = ReaderStreamedOptions::new().read_file(FILE_NAME).unwrap();

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,18 +1,18 @@
-use nifti::{Endianness, NiftiHeader, NiftiType};
+use nifti::{Endianness, NiftiHeader, Nifti1Header, NiftiType};
 
 /// Known meta-data for the "minimal.nii" test file.
 #[allow(dead_code)]
 pub fn minimal_header_nii_gt() -> NiftiHeader {
-    NiftiHeader {
+    Nifti1Header {
         vox_offset: 352.,
         magic: *b"n+1\0",
-        ..minimal_header_hdr_gt()
-    }
+        ..minimal_header_hdr_gt().into_nifti1().unwrap()
+    }.into_nifti()
 }
 
 /// Known meta-data for the "minimal.hdr" test file.
 pub fn minimal_header_hdr_gt() -> NiftiHeader {
-    NiftiHeader {
+    Nifti1Header {
         sizeof_hdr: 348,
         dim: [3, 64, 64, 10, 0, 0, 0, 0],
         datatype: NiftiType::Uint8 as i16,
@@ -29,17 +29,17 @@ pub fn minimal_header_hdr_gt() -> NiftiHeader {
         magic: *b"ni1\0",
         endianness: Endianness::Big,
         ..Default::default()
-    }
+    }.into_nifti()
 }
 
 /// Known meta-data for the RGB volume test file.
 #[allow(dead_code)]
 pub fn rgb_header_gt() -> NiftiHeader {
-    NiftiHeader {
+    Nifti1Header {
         datatype: NiftiType::Rgb24 as i16,
         sform_code: 2,
         qform_code: 0,
         endianness: Endianness::Little,
-        ..NiftiHeader::default()
-    }
+        ..Default::default()
+    }.into_nifti()
 }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,4 +1,5 @@
 use nifti::{Endianness, Nifti1Header, NiftiHeader, NiftiType};
+use std::convert::TryInto;
 
 /// Known meta-data for the "minimal.nii" test file.
 #[allow(dead_code)]
@@ -6,7 +7,7 @@ pub fn minimal_header_nii_gt() -> NiftiHeader {
     Nifti1Header {
         vox_offset: 352.,
         magic: *b"n+1\0",
-        ..minimal_header_hdr_gt().into_nifti1().unwrap()
+        ..minimal_header_hdr_gt().try_into().unwrap()
     }
     .into()
 }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,4 +1,4 @@
-use nifti::{Endianness, NiftiHeader, Nifti1Header, NiftiType};
+use nifti::{Endianness, Nifti1Header, NiftiHeader, NiftiType};
 
 /// Known meta-data for the "minimal.nii" test file.
 #[allow(dead_code)]
@@ -7,7 +7,8 @@ pub fn minimal_header_nii_gt() -> NiftiHeader {
         vox_offset: 352.,
         magic: *b"n+1\0",
         ..minimal_header_hdr_gt().into_nifti1().unwrap()
-    }.into_nifti()
+    }
+    .into_nifti()
 }
 
 /// Known meta-data for the "minimal.hdr" test file.
@@ -29,7 +30,8 @@ pub fn minimal_header_hdr_gt() -> NiftiHeader {
         magic: *b"ni1\0",
         endianness: Endianness::Big,
         ..Default::default()
-    }.into_nifti()
+    }
+    .into_nifti()
 }
 
 /// Known meta-data for the RGB volume test file.
@@ -41,5 +43,6 @@ pub fn rgb_header_gt() -> NiftiHeader {
         qform_code: 0,
         endianness: Endianness::Little,
         ..Default::default()
-    }.into_nifti()
+    }
+    .into_nifti()
 }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -8,7 +8,7 @@ pub fn minimal_header_nii_gt() -> NiftiHeader {
         magic: *b"n+1\0",
         ..minimal_header_hdr_gt().into_nifti1().unwrap()
     }
-    .into_nifti()
+    .into()
 }
 
 /// Known meta-data for the "minimal.hdr" test file.
@@ -31,7 +31,7 @@ pub fn minimal_header_hdr_gt() -> NiftiHeader {
         endianness: Endianness::Big,
         ..Default::default()
     }
-    .into_nifti()
+    .into()
 }
 
 /// Known meta-data for the RGB volume test file.
@@ -44,5 +44,5 @@ pub fn rgb_header_gt() -> NiftiHeader {
         endianness: Endianness::Little,
         ..Default::default()
     }
-    .into_nifti()
+    .into()
 }

--- a/tests/writer.rs
+++ b/tests/writer.rs
@@ -79,8 +79,8 @@ mod tests {
     fn test_write_read(arr: Array<f32, IxDyn>, path: &str) {
         let path = get_temporary_path(path);
         let dim = *Dim::from_slice(arr.shape()).unwrap().raw();
-        let header = generate_nifti1_header(dim.map(|d| d as u16), 1.0, 0.0, NiftiType::Float32)
-            .into_nifti();
+        let header =
+            generate_nifti1_header(dim.map(|d| d as u16), 1.0, 0.0, NiftiType::Float32).into();
         WriterOptions::new(&path)
             .reference_header(&header)
             .write_nifti(&arr)
@@ -148,8 +148,7 @@ mod tests {
         let path = get_temporary_path("test_slope_inter.nii");
         let dim = *Dim::from_slice(arr.shape()).unwrap().raw();
         let header =
-            generate_nifti1_header(dim.map(|d| d as u16), slope, inter, NiftiType::Float32)
-                .into_nifti();
+            generate_nifti1_header(dim.map(|d| d as u16), slope, inter, NiftiType::Float32).into();
         let transformed_data = arr.mul(slope).add(inter);
         WriterOptions::new(&path)
             .reference_header(&header)
@@ -170,7 +169,7 @@ mod tests {
         let dim = [3, 6, 6, 6, 1, 1, 1, 1];
         let slope = 0.4;
         let inter = 100.1;
-        let header = generate_nifti1_header(dim, slope, inter, NiftiType::Uint8).into_nifti();
+        let header = generate_nifti1_header(dim, slope, inter, NiftiType::Uint8).into();
 
         let path = get_temporary_path("test_slope_inter.nii");
         WriterOptions::new(&path)
@@ -221,7 +220,7 @@ mod tests {
     #[test]
     fn write_wrong_description() {
         let dim = [3, 3, 4, 5, 1, 1, 1, 1];
-        let header = generate_nifti1_header(dim, 1.0, 0.0, NiftiType::Float32).into_nifti();
+        let header: NiftiHeader = generate_nifti1_header(dim, 1.0, 0.0, NiftiType::Float32).into();
         let path = get_temporary_path("error_description.nii");
         let data = Array::from_elem((3, 4, 5), 1.5);
 
@@ -230,7 +229,7 @@ mod tests {
         let v = "äbcdé".as_bytes();
         let mut header = header.into_nifti1().unwrap();
         header.descrip[..v.len()].copy_from_slice(&v);
-        let mut header = header.into_nifti();
+        let mut header = header.into();
         WriterOptions::new(&path)
             .reference_header(&header)
             .write_nifti(&data)
@@ -264,7 +263,8 @@ mod tests {
     #[test]
     fn write_set_description_panic() {
         let dim = [3, 3, 4, 5, 1, 1, 1, 1];
-        let mut header = generate_nifti1_header(dim, 1.0, 0.0, NiftiType::Float32).into_nifti();
+        let mut header: NiftiHeader =
+            generate_nifti1_header(dim, 1.0, 0.0, NiftiType::Float32).into();
         assert!(header
             .set_description((0..81).into_iter().collect::<Vec<_>>())
             .is_err());
@@ -273,7 +273,8 @@ mod tests {
     #[test]
     fn write_set_description_str_panic() {
         let dim = [3, 3, 4, 5, 1, 1, 1, 1];
-        let mut header = generate_nifti1_header(dim, 1.0, 0.0, NiftiType::Float32).into_nifti();
+        let mut header: NiftiHeader =
+            generate_nifti1_header(dim, 1.0, 0.0, NiftiType::Float32).into();
         let description: String = std::iter::repeat('é').take(41).collect();
         assert!(header.set_description_str(description).is_err());
     }

--- a/tests/writer.rs
+++ b/tests/writer.rs
@@ -179,8 +179,8 @@ mod tests {
             .unwrap();
 
         let (read_header, read_data) = read_as_ndarray(path);
-        assert_eq!(read_header.get_scl_inter(), 0.0);
-        assert_eq!(read_header.get_scl_slope(), 1.0);
+        assert_eq!(read_header.scl_inter(), 0.0);
+        assert_eq!(read_header.scl_slope(), 1.0);
         assert_eq!(data, read_data);
     }
 

--- a/tests/writer.rs
+++ b/tests/writer.rs
@@ -12,6 +12,7 @@ mod util;
 #[cfg(feature = "ndarray_volumes")]
 mod tests {
     use std::{
+        convert::TryInto,
         fs,
         ops::{Add, Mul},
         path::{Path, PathBuf},
@@ -227,7 +228,7 @@ mod tests {
         // Manual descrip. The original header won't be "repaired", but the written description
         // should be right. To compare the header, we must fix it ourselves.
         let v = "äbcdé".as_bytes();
-        let mut header = header.into_nifti1().unwrap();
+        let mut header: Nifti1Header = header.try_into().unwrap();
         header.descrip[..v.len()].copy_from_slice(&v);
         let mut header = header.into();
         WriterOptions::new(&path)

--- a/tests/writer.rs
+++ b/tests/writer.rs
@@ -28,7 +28,7 @@ mod tests {
         object::NiftiObject,
         volume::shape::Dim,
         writer::WriterOptions,
-        DataElement, IntoNdArray, NiftiHeader, Nifti1Header, NiftiType, ReaderOptions,
+        DataElement, IntoNdArray, Nifti1Header, NiftiHeader, NiftiType, ReaderOptions,
     };
 
     use super::util::rgb_header_gt;
@@ -79,7 +79,8 @@ mod tests {
     fn test_write_read(arr: Array<f32, IxDyn>, path: &str) {
         let path = get_temporary_path(path);
         let dim = *Dim::from_slice(arr.shape()).unwrap().raw();
-        let header = generate_nifti1_header(dim.map(|d| d as u16), 1.0, 0.0, NiftiType::Float32).into_nifti();
+        let header = generate_nifti1_header(dim.map(|d| d as u16), 1.0, 0.0, NiftiType::Float32)
+            .into_nifti();
         WriterOptions::new(&path)
             .reference_header(&header)
             .write_nifti(&arr)
@@ -146,7 +147,9 @@ mod tests {
 
         let path = get_temporary_path("test_slope_inter.nii");
         let dim = *Dim::from_slice(arr.shape()).unwrap().raw();
-        let header = generate_nifti1_header(dim.map(|d| d as u16), slope, inter, NiftiType::Float32).into_nifti();
+        let header =
+            generate_nifti1_header(dim.map(|d| d as u16), slope, inter, NiftiType::Float32)
+                .into_nifti();
         let transformed_data = arr.mul(slope).add(inter);
         WriterOptions::new(&path)
             .reference_header(&header)


### PR DESCRIPTION
This PR is based on #90 , and resolved most issues raised in the original PR, including getters / Into&From traits. The PR also resolved several merge conflicts with current master.

Regarding using f32 for nifti1 when every possible, I don't think it's quite possible with the current NiftiHeader design

```rust
pub enum NiftiHeader {
    /// The underlying header version is `NIFTI-1`.
    Nifti1Header(Nifti1Header),
    /// The underlying header version is `NIFTI-2`.
    Nifti2Header(Nifti2Header),
}
```

We might need to make NiftiHeader a trait with a floating number type defined separately for Nifti1 and Nifti2
