### PR TITLE
Make the set_x_affine functions public

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -487,7 +487,7 @@ impl NiftiHeader {
     }
 
     /// Set affine transformation in 'sform' fields.
-    fn set_sform<T>(&mut self, affine: &Matrix4<T>, code: XForm)
+    pub fn set_sform<T>(&mut self, affine: &Matrix4<T>, code: XForm)
     where
         T: RealField,
         T: ToPrimitive,
@@ -513,7 +513,7 @@ impl NiftiHeader {
     /// components to the `affine` transform, the written qform gives the closest approximation
     /// where the rotation matrix is orthogonal. This is to allow quaternion representation. The
     /// orthogonal representation enforces orthogonal axes.
-    fn set_qform<T>(&mut self, affine4: &Matrix4<T>, code: XForm)
+    pub fn set_qform<T>(&mut self, affine4: &Matrix4<T>, code: XForm)
     where
         T: RealField,
         T: SubsetOf<f64>,


### PR DESCRIPTION
We realized while working on a terrible ANTs affine bug that those functions should be public, so that the programmer has more options than this method:

    pub fn set_affine<T>(&mut self, affine: &Matrix4<T>)
    where
        T: RealField,
        T: SubsetOf<f64>,
        T: ToPrimitive,
    {
        // Set affine into sform with default code.
        self.set_sform(affine, XForm::AlignedAnat);

        // Make qform 'unknown'.
        self.set_qform(affine, XForm::Unknown);
    }

This is our (Imeka) way of doing things, but it may not be everyone else's way.