### PR TITLE
Make error type non-exhaustive

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ use std::io::Error as IOError;
 quick_error! {
     /// Error type for all error variants originated by this crate.
     #[derive(Debug)]
+    #[non_exhaustive]
     pub enum NiftiError {
         /// An invalid NIfTI-1 file was parsed.
         /// This is detected when reading the file's magic code,


### PR DESCRIPTION
A common practice for most error types is to make them non-exhaustive, so that introducing more error variants does not break the API (as is already the case due to #93).