### PR TITLE
Update libs, run clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,32 +18,32 @@ features = ["ndarray_volumes", "nalgebra_affine"]
 [dependencies]
 approx = "0.5"
 byteordered = "0.6"
-flate2 = "1.0"
-num-derive = "0.3"
+flate2 = "1.1"
+num-derive = "0.4"
 num-traits = "0.2"
 quick-error = "2.0"
-either = "1.6"
-num-complex = {version = "0.4.3", features=["bytemuck"]} 
-rgb = "0.8.36"
-bytemuck = {version = "1.13.1", features=["extern_crate_alloc"]}
+either = "1.15"
+num-complex = { version = "0.4", features = ["bytemuck"] }
+rgb = "0.8"
+bytemuck = { version = "1.23", features = ["extern_crate_alloc"] }
 
 [dependencies.nalgebra]
 optional = true
-version = "0.32"
+version = "0.33"
 
 [dependencies.ndarray]
 optional = true
-version = "0.15"
-features = ["approx-0_5"]
+version = "0.16"
+features = ["approx"]
 
 [dependencies.simba]
 default-features = false
 optional = true
-version = "0.8"
+version = "0.9"
 
 [dev-dependencies]
-pretty_assertions = "1.2.1"
-tempfile = "3.1"
+pretty_assertions = "1.4"
+tempfile = "3.20"
 
 [[example]]
 name = "niftidump"

--- a/src/affine.rs
+++ b/src/affine.rs
@@ -7,7 +7,7 @@ pub type Affine3 = Matrix3<f32>;
 /// 4x4 affine transformation matrix.
 pub type Affine4 = Matrix4<f32>;
 
-const QUARTERNION_THRESHOLD: f64 = -::std::f32::EPSILON as f64 * 3.0;
+const QUARTERNION_THRESHOLD: f64 = -f32::EPSILON as f64 * 3.0;
 
 /// Separate a 4x4 affine into its 3x3 affine and translation components.
 pub fn affine_and_translation<T>(affine: &Matrix4<T>) -> (Matrix3<T>, Vector3<T>)
@@ -130,7 +130,7 @@ pub(crate) fn affine_to_quaternion(affine: &Matrix3<f64>) -> RowVector4<f64> {
 #[allow(clippy::many_single_char_names)]
 pub(crate) fn quaternion_to_affine(q: Quaternion<f64>) -> Matrix3<f64> {
     let nq = q.w * q.w + q.i * q.i + q.j * q.j + q.k * q.k;
-    if nq < ::std::f64::EPSILON {
+    if nq < f64::EPSILON {
         return Matrix3::identity();
     }
     let s = 2.0 / nq;

--- a/src/header.rs
+++ b/src/header.rs
@@ -475,7 +475,7 @@ impl NiftiHeader {
     ///
     /// * 'sform' from unmodified `affine`, with `sform_code` set to `AlignedAnat`.
     /// * 'qform' from a quaternion built from `affine`. However, the 'qform' won't be used by most
-    /// nifti readers because the `qform_code` will be set to `Unknown`.
+    ///   nifti readers because the `qform_code` will be set to `Unknown`.
     pub fn set_affine<T>(&mut self, affine: &Matrix4<T>)
     where
         T: RealField,

--- a/src/object.rs
+++ b/src/object.rs
@@ -544,16 +544,7 @@ impl<V> GenericNiftiObject<V> {
             // extensions and volume are in the same source
 
             let extender = Extender::from_reader(&mut stream)?;
-            let len = (header.vox_offset as usize).saturating_sub(352);
-
-            let ext = {
-                let stream = ByteOrdered::runtime(&mut stream, header.endianness);
-                ExtensionSequence::from_reader(extender, stream, len)?
-            };
-
-            let volume = FromSource::from_reader(stream, &header, options)?;
-
-            (volume, ext)
+            GenericNiftiObject::from_reader_with_extensions(stream, &header, extender, options)?
         };
 
         Ok(GenericNiftiObject {

--- a/src/object.rs
+++ b/src/object.rs
@@ -448,7 +448,7 @@ impl<V> GenericNiftiObject<V> {
     /// # Errors
     ///
     /// - `NiftiError::NoVolumeData` if the source only contains (or claims to contain)
-    /// a header.
+    ///   a header.
     pub fn from_reader<R>(mut source: R) -> Result<Self>
     where
         R: Read,
@@ -488,8 +488,7 @@ impl<V> GenericNiftiObject<V> {
         V: FromSource<R>,
     {
         // fetch extensions
-        let len = header.vox_offset as usize;
-        let len = if len < 352 { 0 } else { len - 352 };
+        let len = (header.vox_offset as usize).saturating_sub(352);
 
         let ext = {
             let source = ByteOrdered::runtime(&mut source, header.endianness);
@@ -545,8 +544,7 @@ impl<V> GenericNiftiObject<V> {
             // extensions and volume are in the same source
 
             let extender = Extender::from_reader(&mut stream)?;
-            let len = header.vox_offset as usize;
-            let len = if len < 352 { 0 } else { len - 352 };
+            let len = (header.vox_offset as usize).saturating_sub(352);
 
             let ext = {
                 let stream = ByteOrdered::runtime(&mut stream, header.endianness);

--- a/src/util.rs
+++ b/src/util.rs
@@ -104,8 +104,7 @@ pub fn nb_bytes_for_data(header: &NiftiHeader) -> Result<usize> {
 pub fn nb_values_for_dims(dim: &[u16]) -> Option<usize> {
     dim.iter()
         .cloned()
-        .map(usize::from)
-        .fold(Some(1), |acc, v| acc.and_then(|x| x.checked_mul(v)))
+        .try_fold(1usize, |acc, v| acc.checked_mul(v as usize))
 }
 
 pub fn nb_bytes_for_dim_datatype(dim: &[u16], datatype: NiftiType) -> Option<usize> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,12 +8,9 @@ use either::Either;
 use flate2::bufread::GzDecoder;
 use std::borrow::Cow;
 use std::fs::File;
-use std::io::{BufReader, Read, Result as IoResult, Seek};
+use std::io::{BufReader, Result as IoResult};
 use std::mem;
 use std::path::{Path, PathBuf};
-/// A trait that is both Read and Seek.
-pub trait ReadSeek: Read + Seek {}
-impl<T: Read + Seek> ReadSeek for T {}
 
 pub fn convert_bytes_to<T, E>(mut a: Vec<u8>, e: E) -> Vec<T>
 where

--- a/src/volume/element.rs
+++ b/src/volume/element.rs
@@ -186,7 +186,7 @@ pub trait DataElement: 'static + Sized + Copy {
     type DataRescaler: NiftiDataRescaler<Self>;
 
     /// Read a single element from the given byte source.
-    fn from_raw<R: Read, E>(src: R, endianness: E) -> Result<Self>
+    fn from_raw<R, E>(src: R, endianness: E) -> Result<Self>
     where
         R: Read,
         E: Endian;

--- a/src/volume/inmem.rs
+++ b/src/volume/inmem.rs
@@ -105,7 +105,7 @@ impl InMemNiftiVolume {
         if nbytes != Some(raw_data.len()) {
             return Err(NiftiError::IncompatibleLength(
                 raw_data.len(),
-                nbytes.unwrap_or(usize::max_value()),
+                nbytes.unwrap_or(usize::MAX),
             ));
         }
 
@@ -279,7 +279,7 @@ impl IntoNdArray for InMemNiftiVolume {
 }
 
 #[cfg(feature = "ndarray_volumes")]
-impl<'a> IntoNdArray for &'a InMemNiftiVolume {
+impl IntoNdArray for &InMemNiftiVolume {
     /// Create an ndarray from the given volume.
     fn into_ndarray<T>(self) -> Result<Array<T, IxDyn>>
     where
@@ -289,7 +289,7 @@ impl<'a> IntoNdArray for &'a InMemNiftiVolume {
     }
 }
 
-impl<'a> NiftiVolume for &'a InMemNiftiVolume {
+impl NiftiVolume for &InMemNiftiVolume {
     fn dim(&self) -> &[u16] {
         (**self).dim()
     }
@@ -359,7 +359,7 @@ impl RandomAccessNiftiVolume for InMemNiftiVolume {
     }
 }
 
-impl<'a> RandomAccessNiftiVolume for &'a InMemNiftiVolume {
+impl RandomAccessNiftiVolume for &InMemNiftiVolume {
     fn get_f32(&self, coords: &[u16]) -> Result<f32> {
         (**self).get_f32(coords)
     }

--- a/src/volume/mod.rs
+++ b/src/volume/mod.rs
@@ -57,7 +57,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// # Errors
     ///
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
-    /// volume's boundaries.
+    ///   volume's boundaries.
     fn get_f64(&self, coords: &[u16]) -> Result<f64>;
 
     /// Fetch a single voxel's value in the given voxel index coordinates
@@ -70,7 +70,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// # Errors
     ///
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
-    /// volume's boundaries.
+    ///   volume's boundaries.
     #[inline]
     fn get_f32(&self, coords: &[u16]) -> Result<f32> {
         self.get_f64(coords).map(|v| v as f32)
@@ -86,7 +86,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// # Errors
     ///
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
-    /// volume's boundaries.
+    ///   volume's boundaries.
     #[inline]
     fn get_u8(&self, coords: &[u16]) -> Result<u8> {
         self.get_f64(coords).map(|v| v as u8)
@@ -102,7 +102,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// # Errors
     ///
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
-    /// volume's boundaries.
+    ///   volume's boundaries.
     #[inline]
     fn get_i8(&self, coords: &[u16]) -> Result<i8> {
         self.get_f64(coords).map(|v| v as i8)
@@ -118,7 +118,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// # Errors
     ///
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
-    /// volume's boundaries.
+    ///   volume's boundaries.
     #[inline]
     fn get_u16(&self, coords: &[u16]) -> Result<u16> {
         self.get_f64(coords).map(|v| v as u16)
@@ -134,7 +134,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// # Errors
     ///
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
-    /// volume's boundaries.
+    ///   volume's boundaries.
     #[inline]
     fn get_i16(&self, coords: &[u16]) -> Result<i16> {
         self.get_f64(coords).map(|v| v as i16)
@@ -150,7 +150,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// # Errors
     ///
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
-    /// volume's boundaries.
+    ///   volume's boundaries.
     #[inline]
     fn get_u32(&self, coords: &[u16]) -> Result<u32> {
         self.get_f64(coords).map(|v| v as u32)
@@ -166,7 +166,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// # Errors
     ///
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
-    /// volume's boundaries.
+    ///   volume's boundaries.
     #[inline]
     fn get_i32(&self, coords: &[u16]) -> Result<i32> {
         self.get_f64(coords).map(|v| v as i32)
@@ -182,7 +182,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// # Errors
     ///
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
-    /// volume's boundaries.
+    ///   volume's boundaries.
     #[inline]
     fn get_u64(&self, coords: &[u16]) -> Result<u64> {
         self.get_f64(coords).map(|v| v as u64)
@@ -198,7 +198,7 @@ pub trait RandomAccessNiftiVolume: NiftiVolume {
     /// # Errors
     ///
     /// - `NiftiError::OutOfBounds` if the given coordinates surpass this
-    /// volume's boundaries.
+    ///   volume's boundaries.
     #[inline]
     fn get_i64(&self, coords: &[u16]) -> Result<i64> {
         self.get_f64(coords).map(|v| v as i64)

--- a/src/volume/streamed.rs
+++ b/src/volume/streamed.rs
@@ -243,7 +243,7 @@ where
     }
 }
 
-impl<'a, R> NiftiVolume for &'a StreamedNiftiVolume<R> {
+impl<R> NiftiVolume for &StreamedNiftiVolume<R> {
     fn dim(&self) -> &[u16] {
         (**self).dim()
     }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -96,9 +96,9 @@ impl<'a> WriterOptions<'a> {
     }
 
     /// Loads a reference header from a Nifti file.
-    pub fn reference_file<P: 'a>(mut self, path: &'a P) -> Self
+    pub fn reference_file<P>(mut self, path: &'a P) -> Self
     where
-        P: AsRef<Path>,
+        P: AsRef<Path> + 'a,
     {
         self.header_reference = HeaderReference::FromFile(path.as_ref());
         self

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -426,7 +426,7 @@ where
     E: Endian,
 {
     let len = data.len();
-    let arr_data = data.into_shape(len).unwrap();
+    let arr_data = data.into_shape_with_order(len).unwrap();
     let slice = arr_data.as_slice().unwrap();
     let bytes = cast_slice(slice);
     let (writer, endianness) = writer.into_parts();

--- a/tests/affine.rs
+++ b/tests/affine.rs
@@ -21,13 +21,14 @@ mod nalgebra_affine {
     #[test]
     #[rustfmt::skip]
     fn sform() {
-        let mut header = NiftiHeader::default();
-        header.sform_code = 1;
-        header.qform_code = 0;
-        header.srow_x = [2.4, -0.0008, -0.0411765, -114.766396];
-        header.srow_y = [0.1, 2.4995277, 0.0485984, -97.420204];
-        header.srow_z = [0.4, -0.0485, 2.4991884, -89.12282];
-
+        let header = NiftiHeader {
+            sform_code: 1,
+            qform_code: 0,
+            srow_x: [2.4, -0.0008, -0.0411765, -114.766396],
+            srow_y: [0.1, 2.4995277, 0.0485984, -97.420204],
+            srow_z: [0.4, -0.0485, 2.4991884, -89.12282],
+            .. NiftiHeader::default()
+        };
         let real_affine = Affine4::new(
             2.4, -0.0008,    -0.0411765, -114.766396,
             0.1,  2.4995277,  0.0485984,  -97.420204,
@@ -40,17 +41,18 @@ mod nalgebra_affine {
     #[test]
     #[rustfmt::skip]
     fn qform() {
-        let mut header = NiftiHeader::default();
-        header.sform_code = 0;
-        header.qform_code = 1;
-        header.pixdim = [-1.0, 0.9375, 0.9375, 3.0, 0.0, 0.0, 0.0, 0.0];
-        header.quatern_b = 0.0;
-        header.quatern_c = 1.0;
-        header.quatern_d = 0.0;
-        header.quatern_x = 59.557503;
-        header.quatern_y = 73.172;
-        header.quatern_z = 43.4291;
-
+        let header = NiftiHeader {
+            sform_code: 0,
+            qform_code: 1,
+            pixdim: [-1.0, 0.9375, 0.9375, 3.0, 0.0, 0.0, 0.0, 0.0],
+            quatern_b: 0.0,
+            quatern_c: 1.0,
+            quatern_d: 0.0,
+            quatern_x: 59.557503,
+            quatern_y: 73.172,
+            quatern_z: 43.4291,
+            .. NiftiHeader::default()
+        };
         let real_affine = Affine4::new(
             -0.9375, 0.0,    0.0, 59.557503,
             0.0,     0.9375, 0.0, 73.172,
@@ -63,22 +65,22 @@ mod nalgebra_affine {
     #[test]
     #[rustfmt::skip]
     fn both_valid() {
-        let mut header = NiftiHeader::default();
-        header.sform_code = 1;
-        header.srow_x = [2.4, 0.0, 0.0, -114.766396];
-        header.srow_y = [0.1, 2.4, 0.0, -97.420204];
-        header.srow_z = [0.4, 0.4, 2.4, -89.12282];
-
-        // All this should be ignored
-        header.qform_code = 1;
-        header.pixdim = [-1.0, 0.9375, 0.9375, 3.0, 0.0, 0.0, 0.0, 0.0];
-        header.quatern_b = 0.0;
-        header.quatern_c = 1.0;
-        header.quatern_d = 0.0;
-        header.quatern_x = 59.0;
-        header.quatern_y = 73.0;
-        header.quatern_z = 43.0;
-
+        let header = NiftiHeader {
+            sform_code: 1,
+            srow_x: [2.4, 0.0, 0.0, -114.766396],
+            srow_y: [0.1, 2.4, 0.0, -97.420204],
+            srow_z: [0.4, 0.4, 2.4, -89.12282],
+            // All this should be ignored
+            qform_code: 1,
+            pixdim: [-1.0, 0.9375, 0.9375, 3.0, 0.0, 0.0, 0.0, 0.0],
+            quatern_b: 0.0,
+            quatern_c: 1.0,
+            quatern_d: 0.0,
+            quatern_x: 59.0,
+            quatern_y: 73.0,
+            quatern_z: 43.0,
+            .. NiftiHeader::default()
+        };
         let real_affine = Affine4::new(
             2.4, 0.0, 0.0, -114.766396,
             0.1, 2.4, 0.0, -97.420204,
@@ -91,23 +93,23 @@ mod nalgebra_affine {
     #[test]
     #[rustfmt::skip]
     fn none_valid() {
-        let mut header = NiftiHeader::default();
-        header.dim = [3, 100, 100, 100, 0, 0, 0, 0];
-        header.pixdim = [-1.0, 0.9, 0.9, 3.0, 0.0, 0.0, 0.0, 0.0];
-
-        // All this should be ignored, because only `shape_zoom_affine` will be called.
-        header.sform_code = 0;
-        header.srow_x = [1.0, 0.0, 0.0, 1.0];
-        header.srow_y = [0.0, 1.0, 0.0, 1.0];
-        header.srow_z = [0.0, 0.0, 1.0, 1.0];
-        header.qform_code = 0;
-        header.quatern_b = 0.0;
-        header.quatern_c = 1.0;
-        header.quatern_d = 0.0;
-        header.quatern_x = 59.0;
-        header.quatern_y = 73.0;
-        header.quatern_z = 43.0;
-
+        let header = NiftiHeader {
+            dim: [3, 100, 100, 100, 0, 0, 0, 0],
+            pixdim: [-1.0, 0.9, 0.9, 3.0, 0.0, 0.0, 0.0, 0.0],
+            // All this should be ignored, because only `shape_zoom_affine` will be called.
+            sform_code: 0,
+            srow_x: [1.0, 0.0, 0.0, 1.0],
+            srow_y: [0.0, 1.0, 0.0, 1.0],
+            srow_z: [0.0, 0.0, 1.0, 1.0],
+            qform_code: 0,
+            quatern_b: 0.0,
+            quatern_c: 1.0,
+            quatern_d: 0.0,
+            quatern_x: 59.0,
+            quatern_y: 73.0,
+            quatern_z: 43.0,
+            .. NiftiHeader::default()
+        };
         let real_affine = Affine4::new(
             -0.9, 0.0, 0.0,   44.55,
             0.0,  0.9, 0.0,  -44.55,

--- a/tests/writer.rs
+++ b/tests/writer.rs
@@ -36,7 +36,7 @@ mod tests {
 
     fn get_temporary_path(ext: &str) -> PathBuf {
         let dir = tempdir().unwrap();
-        let mut path = dir.into_path();
+        let mut path = dir.keep();
         if !ext.is_empty() {
             path.push(ext);
         }
@@ -163,7 +163,7 @@ mod tests {
     fn half_slope() {
         let data = (0..216)
             .collect::<Array1<_>>()
-            .into_shape((6, 6, 6))
+            .into_shape_with_order((6, 6, 6))
             .unwrap();
         let dim = [3, 6, 6, 6, 1, 1, 1, 1];
         let slope = 0.4;

--- a/tests/writer.rs
+++ b/tests/writer.rs
@@ -261,7 +261,7 @@ mod tests {
     fn write_descrip_panic() {
         let dim = [3, 3, 4, 5, 1, 1, 1, 1];
         let mut header = generate_nifti_header(dim, 1.0, 0.0, NiftiType::Float32);
-        header.descrip = (0..84).into_iter().collect();
+        header.descrip = (0..84).collect();
         let path = get_temporary_path("error_description.nii");
         let data = Array::from_elem((3, 4, 5), 1.5);
         assert!(WriterOptions::new(&path)
@@ -274,16 +274,14 @@ mod tests {
     fn write_set_description_panic() {
         let dim = [3, 3, 4, 5, 1, 1, 1, 1];
         let mut header = generate_nifti_header(dim, 1.0, 0.0, NiftiType::Float32);
-        assert!(header
-            .set_description((0..81).into_iter().collect::<Vec<_>>())
-            .is_err());
+        assert!(header.set_description((0..81).collect::<Vec<_>>()).is_err());
     }
 
     #[test]
     fn write_set_description_str_panic() {
         let dim = [3, 3, 4, 5, 1, 1, 1, 1];
         let mut header = generate_nifti_header(dim, 1.0, 0.0, NiftiType::Float32);
-        let description: String = std::iter::repeat('é').take(41).collect();
+        let description: String = "é".repeat(41);
         assert!(header.set_description_str(description).is_err());
     }
 
@@ -352,12 +350,8 @@ mod tests {
         // set the bytes of vox_offset to 0.0 and of magic to MAGIC_CODE_NI1. The data bytes should
         // be identical though.
         let mut gt_bytes = fs::read("resources/rgb/3D.nii").unwrap();
-        for i in 110..114 {
-            gt_bytes[i] = 0;
-        }
-        for i in 0..4 {
-            gt_bytes[344 + i] = MAGIC_CODE_NI1[i];
-        }
+        gt_bytes[110..114].fill(0);
+        gt_bytes[344..344 + 4].copy_from_slice(MAGIC_CODE_NI1);
         assert_eq!(fs::read(header_path).unwrap(), &gt_bytes[..352]);
         assert_eq!(fs::read(data_path).unwrap(), &gt_bytes[352..]);
     }


### PR DESCRIPTION
Hi @Enet4,

There wasn't much to release, but I think 2 years is enough for a new release :)

May I have your opinion on this warning?

    /// A trait that is both Read and Seek.
    pub trait ReadSeek: Read + Seek {}
              ^^^^^^^^
              trait `ReadSeek` is never used

I hesitate to remove it because it's a public trait. Anyone could use it... but Clippy should know better than to warn about an unused public trait? Do we simply tell clippy to ignore it?

Also, should we use a newer edition?

We're working on a release of our medical software and `nifti-rs` is the only crate left to update. When we merge this MR, could you please create a release?